### PR TITLE
feat: don't purge tailwind in development mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   purge: {
     mode: 'layers',
+    enabled: process.env.NODE_ENV === 'production',
     content: [fromRoot('./app/**/*.+(js|ts|tsx|mdx|md)')],
   },
   plugins: [require('@tailwindcss/typography')],


### PR DESCRIPTION
This change prevents tailwind (postcss) from purging css in development mode. Making things faster, and reduce the need for full server restarts.