### PR TITLE
feat: add dark-mode switch to storybook

### DIFF
--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -11,7 +11,11 @@ module.exports = {
     '../stories/**/*.stories.mdx',
     '../stories/**/*.stories.@(js|jsx|ts|tsx)',
   ],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    'storybook-dark-mode',
+  ],
 
   // this just wasn't working. Not sure why. Would be cool probably.
   typescript: {

--- a/storybook/.storybook/preview.js
+++ b/storybook/.storybook/preview.js
@@ -1,5 +1,6 @@
 import '@kcd/styles/app.css'
 import '@kcd/styles/tailwind.css'
+import './storybook.css'
 
 export const parameters = {
   actions: {argTypesRegex: '^on[A-Z].*'},
@@ -8,5 +9,12 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  darkMode: {
+    current: 'dark',
+    darkClass: 'dark',
+    lightClass: 'light',
+    classTarget: 'body',
+    stylePreview: true,
   },
 }

--- a/storybook/.storybook/storybook.css
+++ b/storybook/.storybook/storybook.css
@@ -1,0 +1,7 @@
+body {
+  background: #fff;
+}
+
+body.dark {
+  background: #2b2b2b;
+}

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -4412,16 +4412,6 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6998,13 +6988,6 @@
         }
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "filesize": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
@@ -9449,13 +9432,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12187,6 +12163,16 @@
         "ts-dedent": "^2.1.1"
       }
     },
+    "storybook-dark-mode": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.0.8.tgz",
+      "integrity": "sha512-uY6yTSd1vYE0YwlON50u+iIoNF/fmMj59ww1cpd/naUcmOmCjwawViKFG5YjichwdR/yJ5ybWRUF0tnRQfaSiw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.0.0",
+        "memoizerific": "^1.11.3"
+      }
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -13432,11 +13418,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -16,7 +16,7 @@
     "@storybook/addon-essentials": "^6.3.0-rc.0",
     "@storybook/addon-links": "^6.3.0-rc.0",
     "@storybook/react": "^6.3.0-rc.0",
-    "babel-loader": "^8.2.2"
-  },
-  "dependencies": {}
+    "babel-loader": "^8.2.2",
+    "storybook-dark-mode": "^1.0.8"
+  }
 }


### PR DESCRIPTION
Added `storybook-dark-mode`, so we can switch between light and dark mode in storybook.

It defaults to `dark` and applies the `dark` class to the `body` inside the iframe. I use the `storybook.css` file to control the frame's background color. These values should be adjusted to match the real theme when the style guide/color scheme comes in.

Preview:

![storybook-dark-light](https://user-images.githubusercontent.com/1196524/121505884-815c4880-c9e3-11eb-9cce-87cedc4e07db.gif)
