### PR TITLE
feat: serve static files via storybook

### DIFF
--- a/storybook/pm2.config.js
+++ b/storybook/pm2.config.js
@@ -5,7 +5,7 @@ module.exports = {
     {
       name: 'Storybook',
       script:
-        'start-storybook -p 6006 --no-version-updates --no-release-notes --quiet',
+        'start-storybook -p 6006 --no-version-updates --no-release-notes --quiet -s ../public',
       ignore_watch: ['.'], // watch mode is managed by storybook
       cwd: __dirname,
       env: {


### PR DESCRIPTION
Added the `-s` flag to storybook, so that all static files from `/public` are available to it. This helps serving local images for example.

https://storybook.js.org/docs/riot/configure/images-and-assets#serving-static-files-via-storybook

Worth considering, I've only specified the `/public` folder, but we could also add a second folder like `/storybook/fixtures`. This folder could then be used for custom placeholder images that shouldn't be included on production servers.