### PR TITLE
fix: polish home page

### DIFF
--- a/app/components/course-card.tsx
+++ b/app/components/course-card.tsx
@@ -21,7 +21,7 @@ function CourseCard({
   return (
     <div className="relative pt-12 w-full h-full">
       <a
-        className="group relative block pb-10 pt-36 px-8 w-full h-full dark:bg-gray-800 rounded-lg md:pb-20 md:px-16"
+        className="group relative block pb-10 pt-36 px-8 w-full h-full bg-gray-100 dark:bg-gray-800 rounded-lg md:pb-20 md:px-16"
         href={courseUrl}
       >
         <H2>{title}</H2>

--- a/app/components/pages/home.tsx
+++ b/app/components/pages/home.tsx
@@ -19,15 +19,8 @@ import {Spacer} from '../spacer'
 export function HomePage() {
   return (
     <div>
-      <div className="flex flex-col lg:h-screen">
-        <div className="flex-none">
-          <Navbar />
-        </div>
-
-        <div className="flex-auto pb-12">
-          <HeroSection />
-        </div>
-      </div>
+      <Navbar />
+      <HeroSection />
       <Spacer size="large" />
       <IntroductionSection />
       <Spacer size="large" />

--- a/app/components/sections/hero-section.tsx
+++ b/app/components/sections/hero-section.tsx
@@ -7,10 +7,12 @@ import {Button} from '../button'
 // Note that the image overlaps the right edge of the grid by `8vw`. This `8vw`
 // needs to stay in sync with the `10vw` margins of the grid component.
 function HeroSection() {
+  // The grid has a computed height on the large breakpoint, to make the Hero
+  // span the height of the screens, minus 10rem for the navbar (h-40).
   return (
-    <Grid className="h-full">
+    <Grid className="lg:h-[calc(100vh-10rem)] lg:pb-12">
       <div className="relative col-span-full px-4 lg:col-span-6 lg:col-start-7 lg:px-0 lg:h-full">
-        <div className="bottom-0 left-0 right-0 top-0 flex items-center justify-center lg:absolute lg:-right-8vw">
+        <div className="bottom-0 left-0 right-0 top-0 flex items-center justify-center pointer-events-none lg:absolute lg:-right-8vw">
           <img
             alt="A mascot standing on a snowboard surrounded by green leaves, a battery, two skies, a one-wheel, a solar panel and a recycle logo."
             className="w-full h-auto max-h-screen object-contain"

--- a/app/components/sections/problem-solution-section.tsx
+++ b/app/components/sections/problem-solution-section.tsx
@@ -18,7 +18,7 @@ function Tab({isSelected, children}: TabProps & {isSelected?: boolean}) {
   return (
     <ReachTab
       className={clsx(
-        'inline-flex items-center w-full lowercase space-x-8 transition',
+        'inline-flex items-center w-full focus:bg-transparent border-none lowercase space-x-8 transition',
         {
           'text-black dark:text-white': isSelected,
           'dark:text-blueGray-500 text-gray-400': !isSelected,
@@ -94,7 +94,7 @@ function ProblemSolutionSection() {
             </TabPanels>
 
             <div className="col-span-full col-start-1 order-1 lg:col-span-5 lg:order-3">
-              <TabList className="inline-flex flex-row text-white text-xl space-x-8 lg:flex-col lg:text-7xl lg:space-x-0 lg:space-y-7">
+              <TabList className="inline-flex flex-row text-white text-xl bg-transparent space-x-8 lg:flex-col lg:text-7xl lg:space-x-0 lg:space-y-7">
                 <Tab>Blog</Tab>
                 <Tab>Courses</Tab>
                 <Tab>Podcast</Tab>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -28,6 +28,7 @@ import {getEnv} from './utils/env.server'
 import {Navbar} from './components/navbar'
 import {Spacer} from './components/spacer'
 import {Footer} from './components/footer'
+import clsx from 'clsx'
 
 export const meta: MetaFunction = ({data}: {data: LoaderData}) => {
   const theme = getThemeFromMedia(data.theme)
@@ -52,8 +53,8 @@ export const meta: MetaFunction = ({data}: {data: LoaderData}) => {
 export const links: LinksFunction = () => {
   return [
     {rel: 'icon', href: '/favicon.ico'},
-    {rel: 'stylesheet', href: tailwind},
     {rel: 'stylesheet', href: styles},
+    {rel: 'stylesheet', href: tailwind},
   ]
 }
 
@@ -90,10 +91,15 @@ function App() {
         <Links />
       </head>
       <body
-        // TODO: switch this to clsx when Stephan's PR that adds it is merged
-        className={[showPendingState ? 'opacity-50' : null, theme]
-          .filter(Boolean)
-          .join(' ')}
+        className={clsx(
+          'transition',
+          {
+            'opacity-50': showPendingState,
+            'bg-gray-900': theme === 'dark',
+            'bg-white': theme === 'light',
+          },
+          theme,
+        )}
       >
         <script
           // NOTE: this *has* to be set to the data.theme for the JS to be


### PR DESCRIPTION
- changed hero to match screen height, without the navbar+hero wrapper.
- fixed the `course-card` to have a background on light mode
- fixed the `@reach/tabs` to have correct styles when `@reach/tabs/style.css` is imported, by changing the app.css and tailwind.css load order
- fixed page background color for light/dark modes