### PR TITLE
feat: add blog detail page

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -155,7 +155,7 @@ function Footer() {
           <ContactSection />
         </div>
 
-        <div className="col-span-2 mt-20 md:col-start-7 md:row-start-1 md:mt-0 lg:col-start-5 lg:row-start-2 lg:mt-10">
+        <div className="col-span-2 mt-20 md:col-start-7 md:row-start-1 md:mt-0 lg:col-start-5 lg:row-start-2 lg:mt-16">
           <GeneralSection />
         </div>
 
@@ -173,7 +173,7 @@ function Footer() {
           </div>
         )}
 
-        <div className="col-span-full mt-20 dark:text-blueGray-500 text-gray-500 text-lg md:mt-36">
+        <div className="col-span-full mt-24 dark:text-blueGray-500 text-gray-500 text-lg md:mt-44">
           <span>All rights reserved</span>{' '}
           <span className="block md:inline">{`© Kent C. Dodds ${new Date().getFullYear()}`}</span>
         </div>

--- a/app/components/grid.tsx
+++ b/app/components/grid.tsx
@@ -5,11 +5,14 @@ interface GridProps {
   children: React.ReactNode
   overflow?: boolean
   className?: string
+  as?: React.ElementType
 }
 
-function Grid({children, className}: GridProps) {
+function Grid({children, className, as = 'div'}: GridProps) {
+  const Tag = as
+
   return (
-    <div className="mx-10vw">
+    <Tag className="mx-10vw">
       <div
         className={clsx(
           'grid gap-x-4 grid-cols-4 mx-auto max-w-7xl md:grid-cols-8 lg:gap-x-6 lg:grid-cols-12',
@@ -18,7 +21,7 @@ function Grid({children, className}: GridProps) {
       >
         {children}
       </div>
-    </div>
+    </Tag>
   )
 }
 

--- a/app/components/grid.tsx
+++ b/app/components/grid.tsx
@@ -12,7 +12,7 @@ function Grid({children, className}: GridProps) {
     <div className="mx-10vw">
       <div
         className={clsx(
-          'grid gap-4 grid-cols-4 mx-auto max-w-7xl md:grid-cols-8 lg:gap-6 lg:grid-cols-12',
+          'grid gap-x-4 grid-cols-4 mx-auto max-w-7xl md:grid-cols-8 lg:gap-x-6 lg:grid-cols-12',
           className,
         )}
       >

--- a/app/components/sections/blog-section.tsx
+++ b/app/components/sections/blog-section.tsx
@@ -6,18 +6,32 @@ import {ArrowButton} from '../arrow-button'
 import {Grid} from '../grid'
 import {ArticleCard} from '../article-card'
 
-function BlogSection({articles}: {articles: Array<MdxListItem>}) {
+interface BlogSectionProps {
+  articles: Array<MdxListItem>
+  title: string
+  description: string
+  showArrowButton?: boolean
+}
+
+function BlogSection({
+  articles,
+  title,
+  description,
+  showArrowButton,
+}: BlogSectionProps) {
   return (
     <Grid>
-      <div className="flex flex-col col-span-full mb-10 space-y-10 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
+      <div className="flex flex-col col-span-full mb-20 space-y-10 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
         <div className="space-y-2 lg:space-y-0">
-          <H2>Most popular from the blog.</H2>
+          <H2>{title}</H2>
           <H2 variant="secondary" as="p">
-            Probably the most helpful as well.
+            {description}
           </H2>
         </div>
 
-        <ArrowButton direction="right">See the full blog</ArrowButton>
+        {showArrowButton === false ? null : (
+          <ArrowButton direction="right">See the full blog</ArrowButton>
+        )}
       </div>
 
       {articles.slice(0, 3).map((article, idx) => (

--- a/app/components/sections/course-section.tsx
+++ b/app/components/sections/course-section.tsx
@@ -7,7 +7,7 @@ import {CourseCard} from '../course-card'
 function CourseSection() {
   return (
     <Grid>
-      <div className="flex flex-col col-span-full mb-10 space-y-10 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
+      <div className="flex flex-col col-span-full mb-20 space-y-10 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
         <div className="space-y-2 lg:space-y-0">
           <H2>Have a look at some of the courses.</H2>
           <H2 variant="secondary" as="p">

--- a/app/components/sections/problem-solution-section.tsx
+++ b/app/components/sections/problem-solution-section.tsx
@@ -62,7 +62,7 @@ function ProblemSolutionSection() {
               </H2>
             </div>
 
-            <hr className="col-span-full mb-16 mt-20 border-gray-200 dark:border-gray-600" />
+            <hr className="col-span-full mb-20 mt-24 border-gray-200 dark:border-gray-600" />
 
             {/*
               Note that we use two TabPanels for a single TabList, so that we can
@@ -94,7 +94,7 @@ function ProblemSolutionSection() {
               </TabPanel>
             </TabPanels>
 
-            <div className="col-span-full col-start-1 order-1 lg:col-span-5 lg:order-3">
+            <div className="col-span-full col-start-1 order-1 lg:col-span-5 lg:order-3 lg:mt-5">
               <TabList className="inline-flex flex-row text-white text-xl bg-transparent space-x-8 lg:flex-col lg:text-7xl lg:space-x-0 lg:space-y-7">
                 <Tab>Blog</Tab>
                 <Tab>Courses</Tab>
@@ -102,7 +102,7 @@ function ProblemSolutionSection() {
               </TabList>
             </div>
 
-            <TabPanels className="col-span-full order-4 mt-6 space-y-7 lg:col-span-5 lg:col-start-7">
+            <TabPanels className="col-span-full order-4 mt-14 space-y-7 lg:col-span-5 lg:col-start-7">
               <TabPanel>
                 <H3>Educational blog</H3>
 

--- a/app/components/tag.tsx
+++ b/app/components/tag.tsx
@@ -19,7 +19,7 @@ function Tag({tag, selected, onClick}: TagProps) {
         checked={selected}
         onChange={onClick}
         className={clsx(
-          'relative block ml-4 mt-4 px-6 py-3 w-auto h-auto rounded-full focus-within:outline-none transition ring-gray-200 dark:ring-gray-600 dark:ring-offset-gray-900 ring-offset-white ring-offset-4 focus-within:ring-2',
+          'relative block mb-4 mr-4 px-6 py-3 w-auto h-auto rounded-full focus-within:outline-none transition ring-gray-200 dark:ring-gray-600 dark:ring-offset-gray-900 ring-offset-white ring-offset-4 hover:ring-2 focus-within:ring-2',
           {
             'text-black dark:text-white bg-gray-100 dark:bg-gray-800':
               !selected,

--- a/app/components/typography.tsx
+++ b/app/components/typography.tsx
@@ -62,12 +62,20 @@ function H6(props: TitleProps) {
 }
 
 interface ParagraphProps {
-  children: string
+  children: React.ReactNode
+  className?: string
 }
 
-function Paragraph({children}: ParagraphProps) {
+function Paragraph({children, className}: ParagraphProps) {
   return (
-    <p className="dark:text-blueGray-500 text-gray-500 text-lg">{children}</p>
+    <p
+      className={clsx(
+        'dark:text-blueGray-500 text-gray-500 text-lg',
+        className,
+      )}
+    >
+      {children}
+    </p>
   )
 }
 

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import {useRouteData, json} from 'remix'
-import {useParams} from 'react-router-dom'
+import {Link, useParams} from 'react-router-dom'
 import type {KCDLoader, MdxPage} from 'types'
+import formatDate from 'date-fns/format'
 import {
   FourOhFour,
   getMdxPage,
@@ -9,6 +10,13 @@ import {
   getMdxComponent,
 } from '../../utils/mdx'
 import {useOptionalUser} from '../../utils/misc'
+import {H2, H6, Paragraph} from '../../components/typography'
+import {Grid} from '../../components/grid'
+import {ArrowIcon} from '../../components/icons/arrow-icon'
+import {Spacer} from '../../components/spacer'
+import {ArrowLink} from '../../components/arrow-button'
+import {BlogSection} from '../../components/sections/blog-section'
+import {articles} from '../../../storybook/stories/fixtures'
 
 type LoaderData = {
   page: MdxPage | null
@@ -118,6 +126,65 @@ function useOnRead({
   }, [enabled, readTime, onRead, parentElRef])
 }
 
+function ArticleFooter() {
+  return (
+    <Grid>
+      <div className="flex flex-col col-span-full justify-between mb-12 pb-12 text-blueGray-500 text-lg font-medium border-b border-gray-600 lg:flex-row lg:col-span-8 lg:col-start-3 lg:pb-6">
+        <div className="flex space-x-5">
+          <H6>Share article</H6>
+          {/* TODO: fix links */}
+          <Link
+            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            to="/"
+          >
+            Facebook
+          </Link>
+          <Link
+            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            to="/"
+          >
+            Twitter
+          </Link>
+        </div>
+
+        <div className="flex items-center">
+          <Link
+            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            to="/"
+          >
+            Discuss on Twitter
+          </Link>
+          <span className="mx-3 text-xs">•</span>
+          <Link
+            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            to="/"
+          >
+            Edit on GitHub
+          </Link>
+        </div>
+      </div>
+      <div className="col-span-full lg:col-span-2 lg:col-start-3">
+        {/* TODO: replace with correct profile photo */}
+        <img
+          src="https://kentcdodds.com/static/kent-985f8a0db8a37e47da2c07080cffa865.png"
+          alt="Kent C. Dodds"
+          className="mb-8 w-32 rounded-lg"
+        />
+      </div>
+      <div className="lg:col-start:5 col-span-full lg:col-span-6">
+        <H6>Written by Kent C. Dodds</H6>
+        <Paragraph className="mb-12 mt-3">
+          Kent C. Dodds is a JavaScript software engineer and teacher. He's
+          taught hundreds of thousands of people how to make the world a better
+          place with quality software development tools and practices. He lives
+          with his wife and four kids in Utah.
+        </Paragraph>
+        <ArrowLink to="/about">Learn more about Kent</ArrowLink>
+      </div>
+    </Grid>
+  )
+}
+
 function MdxScreen() {
   const data = useRouteData<LoaderData>()
   if (!data.page) {
@@ -131,9 +198,9 @@ function MdxScreen() {
   const {slug} = params
   const Component = React.useMemo(() => getMdxComponent(code), [code])
 
-  const mainRef = React.useRef<HTMLDivElement>(null)
+  const readMarker = React.useRef<HTMLDivElement>(null)
   useOnRead({
-    parentElRef: mainRef,
+    parentElRef: readMarker,
     readTime: data.page.readTime,
     onRead: React.useCallback(() => {
       const searchParams = new URLSearchParams([
@@ -149,13 +216,57 @@ function MdxScreen() {
 
   return (
     <>
-      <header>
-        <h2>{frontmatter.title}</h2>
-        <p>{frontmatter.description}</p>
-      </header>
-      <main ref={mainRef}>
+      <Spacer size="smaller" />
+
+      <Grid>
+        <Link
+          to="/"
+          className="flex col-span-full text-black dark:text-white space-x-4 lg:col-span-8 lg:col-start-3"
+        >
+          <ArrowIcon direction="left" />
+          <H6 as="span">Back to overview</H6>
+        </Link>
+      </Grid>
+
+      <Spacer size="smaller" />
+
+      <Grid as="header">
+        <div className="col-span-full lg:col-span-8 lg:col-start-3">
+          <H2>{frontmatter.title}</H2>
+          {/* TODO: add readTime */}
+          <H6 as="p" variant="secondary" className="mt-2 lowercase">
+            {frontmatter.date
+              ? formatDate(new Date(frontmatter.date), 'PPP')
+              : 'some day in the past'}{' '}
+            — quick read
+          </H6>
+        </div>
+        <img
+          className="col-span-full mt-10 rounded-lg lg:col-span-10 lg:col-start-2"
+          src={frontmatter.bannerUrl}
+          alt={frontmatter.bannerAlt}
+        />
+      </Grid>
+
+      <Spacer size="smallest" />
+      <div ref={readMarker} />
+
+      <Grid as="main" className="prose prose-light dark:prose-dark">
         <Component />
-      </main>
+      </Grid>
+
+      <Spacer size="small" />
+      <ArticleFooter />
+
+      <Spacer size="large" />
+      {/* TODO: replace `articles` with something smart from the backend */}
+      <BlogSection
+        articles={articles}
+        title="If you found this article helpful."
+        description="
+            You will love these ones as well."
+        showArrowButton={false}
+      />
     </>
   )
 }

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -14,7 +14,6 @@ import {useOptionalUser} from '../../utils/misc'
 import {H2, H6, Paragraph} from '../../components/typography'
 import {Grid} from '../../components/grid'
 import {ArrowIcon} from '../../components/icons/arrow-icon'
-import {Spacer} from '../../components/spacer'
 import {ArrowLink} from '../../components/arrow-button'
 import {BlogSection} from '../../components/sections/blog-section'
 import {articles} from '../../../storybook/stories/fixtures'
@@ -223,9 +222,7 @@ function MdxScreen() {
 
   return (
     <>
-      <Spacer size="smaller" />
-
-      <Grid>
+      <Grid className="mb-24 mt-24">
         <Link
           to="/"
           className="flex col-span-full text-black dark:text-white space-x-4 lg:col-span-8 lg:col-start-3"
@@ -235,9 +232,7 @@ function MdxScreen() {
         </Link>
       </Grid>
 
-      <Spacer size="smaller" />
-
-      <Grid as="header">
+      <Grid as="header" className="mb-12">
         <div className="col-span-full lg:col-span-8 lg:col-start-3">
           <H2>{frontmatter.title}</H2>
           {/* TODO: add readTime */}
@@ -255,17 +250,16 @@ function MdxScreen() {
         />
       </Grid>
 
-      <Spacer size="smallest" />
       <div ref={readMarker} />
 
-      <Grid as="main" className="prose prose-light dark:prose-dark">
+      <Grid as="main" className="prose prose-light dark:prose-dark mb-24">
         <Component components={MdxComponentMap} />
       </Grid>
 
-      <Spacer size="small" />
-      <ArticleFooter />
+      <div className="mb-64">
+        <ArticleFooter />
+      </div>
 
-      <Spacer size="large" />
       {/* TODO: replace `articles` with something smart from the backend */}
       <BlogSection
         articles={articles}

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -3,6 +3,7 @@ import {useRouteData, json} from 'remix'
 import {Link, useParams} from 'react-router-dom'
 import type {KCDLoader, MdxPage} from 'types'
 import formatDate from 'date-fns/format'
+import type {ComponentMap} from 'mdx-bundler/client'
 import {
   FourOhFour,
   getMdxPage,
@@ -185,6 +186,12 @@ function ArticleFooter() {
   )
 }
 
+const MdxComponentMap: ComponentMap = {
+  // remove extra wrapping div from elements like <div> (TheSpectrumOfAbstraction) and <pre> (code blocks)
+  // eslint-disable-next-line react/display-name
+  div: ({children}) => <>{children}</>,
+}
+
 function MdxScreen() {
   const data = useRouteData<LoaderData>()
   if (!data.page) {
@@ -252,7 +259,7 @@ function MdxScreen() {
       <div ref={readMarker} />
 
       <Grid as="main" className="prose prose-light dark:prose-dark">
-        <Component />
+        <Component components={MdxComponentMap} />
       </Grid>
 
       <Spacer size="small" />

--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -192,7 +192,7 @@ function BlogHome() {
           </div>
         </div>
 
-        <div className="col-span-4 mt-6 lg:row-start-2">
+        <div className="col-span-4 mt-12 lg:row-start-2">
           <div className="relative">
             <div className="absolute left-8 top-0 flex items-center justify-center h-full text-blueGray-500">
               <SearchIcon />

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -20,7 +20,12 @@ function IndexRoute() {
       <ProblemSolutionSection />
       <Spacer size="medium" />
       {/*  TODO: replace fixtures */}
-      <BlogSection articles={articles} />
+      <BlogSection
+        articles={articles}
+        title="Most popular from the blog."
+        description="
+            Probably the most helpful as well."
+      />
       <Spacer size="large" />
       <CourseSection />
       <Spacer size="large" />

--- a/app/utils/mdx.tsx
+++ b/app/utils/mdx.tsx
@@ -113,7 +113,7 @@ function getMdxComponent(code: string) {
     components,
     ...rest
   }: Parameters<typeof Component>['0']) {
-    return <Component component={{a: AnchorOrLink, ...components}} {...rest} />
+    return <Component components={{a: AnchorOrLink, ...components}} {...rest} />
   }
   return KCDMdxComponent
 }

--- a/storybook/stories/sections.stories.tsx
+++ b/storybook/stories/sections.stories.tsx
@@ -31,7 +31,14 @@ function HeroSection() {
   )
 }
 
-const BlogSection = () => <BlogSectionComponent articles={fixtures.articles} />
+const BlogSection = () => (
+  <BlogSectionComponent
+    articles={fixtures.articles}
+    title="Most popular from the blog."
+    description="
+            Probably the most helpful as well."
+  />
+)
 
 export {
   AboutSection,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -77,6 +77,12 @@ module.exports = {
       },
 
       typography: theme => {
+        // some fontSizes return [size, props], others just size :/
+        const fontSize = size => {
+          const result = theme(`fontSize.${size}`)
+          return Array.isArray(result) ? result[0] : result
+        }
+
         return {
           DEFAULT: {
             css: [
@@ -92,7 +98,12 @@ module.exports = {
                 p: {
                   marginTop: theme('spacing.10'),
                   marginBottom: 0,
-                  fontSize: theme('fontSize.lg.0'),
+                  fontSize: fontSize('lg'),
+                },
+                '> div': {
+                  marginTop: theme('spacing.10'),
+                  marginBottom: 0,
+                  fontSize: fontSize('lg'),
                 },
                 a: {
                   color: theme('colors.black'),
@@ -101,6 +112,25 @@ module.exports = {
                 strong: {
                   color: theme('colors.black'),
                   fontWeight: theme('fontWeight.medium'),
+                },
+                hr: {
+                  marginTop: theme('spacing.10'),
+                  marginBottom: theme('spacing.10'),
+                  borderColor: theme('colors.gray.200'),
+                },
+                pre: {
+                  // TODO: remove important
+                  backgroundColor: `${theme('colors.gray.100')} !important`,
+                  color: `${theme('colors.gray.800')} !important`,
+                  padding: theme('spacing.8'),
+                  borderRadius: theme('borderRadius.lg'),
+
+                  [`@media (min-width: ${theme('screens.lg')})`]: {
+                    gridColumn: '2 / span 10',
+                  },
+                },
+                'pre code': {
+                  color: `${theme('colors.gray.800')} !important`,
                 },
                 code: {
                   color: theme('colors.gray.800'),
@@ -123,24 +153,24 @@ module.exports = {
                 },
                 // tailwind doesn't stick to this property order, so we can't make 'h3' overrule 'h2, h3, h4'
                 'h1, h2': {
-                  fontSize: theme('fontSize.2xl.0'),
+                  fontSize: fontSize('2xl'),
                   marginTop: theme('spacing.32'),
                   [`@media (min-width: ${theme('screens.lg')})`]: {
-                    fontSize: theme('fontSize.3xl.0'),
+                    fontSize: fontSize('3xl'),
                   },
                 },
                 h3: {
-                  fontSize: theme('fontSize.xl.0'),
+                  fontSize: fontSize('xl'),
                   marginTop: theme('spacing.24'),
                   [`@media (min-width: ${theme('screens.lg')})`]: {
-                    fontSize: theme('fontSize.2xl.0'),
+                    fontSize: fontSize('2xl'),
                   },
                 },
                 'h4, h5, h6': {
-                  fontSize: theme('fontSize.lg.0'),
+                  fontSize: fontSize('lg'),
                   marginTop: theme('spacing.10'),
                   [`@media (min-width: ${theme('screens.lg')})`]: {
-                    fontSize: theme('fontSize.xl.0'),
+                    fontSize: fontSize('xl'),
                   },
                 },
                 img: {
@@ -150,10 +180,14 @@ module.exports = {
                   marginBottom: 0,
                 },
                 blockquote: {
-                  color: theme('colors.gray.800'),
+                  color: theme('colors.gray.500'),
+                  backgroundColor: theme('colors.gray.100'),
                   fontWeight: theme('fontWeight.normal'),
+                  border: 'none',
+                  borderRadius: theme('borderRadius.lg'),
+                  padding: theme('spacing.8'),
                 },
-                'blockquote > p:first-child': {
+                'blockquote > :first-child': {
                   marginTop: 0,
                 },
               },
@@ -163,12 +197,22 @@ module.exports = {
             css: [
               {
                 color: theme('colors.blueGray.500'),
-
                 a: {
                   color: theme('colors.white'),
                 },
                 strong: {
                   color: theme('colors.white'),
+                },
+                hr: {
+                  borderColor: theme('colors.gray.600'),
+                },
+                pre: {
+                  // TODO: remove !important
+                  backgroundColor: `${theme('colors.gray.800')} !important`,
+                  color: `${theme('colors.gray.200')} !important`,
+                },
+                'pre code': {
+                  color: `${theme('colors.gray.200')} !important`,
                 },
                 code: {
                   color: theme('colors.gray.100'),
@@ -178,6 +222,7 @@ module.exports = {
                 },
                 blockquote: {
                   color: theme('colors.blueGray.500'),
+                  backgroundColor: theme('colors.gray.800'),
                 },
               },
             ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,10 +84,11 @@ module.exports = {
         }
 
         return {
+          // DEFAULT only holds shared stuff and not the things that change
+          // between light/dark
           DEFAULT: {
             css: [
               {
-                color: theme('colors.gray.500'),
                 '> *': {
                   gridColumn: '1 / -1',
 
@@ -96,32 +97,28 @@ module.exports = {
                   },
                 },
                 p: {
-                  marginTop: theme('spacing.10'),
-                  marginBottom: 0,
+                  marginTop: 0,
+                  marginBottom: theme('spacing.8'),
                   fontSize: fontSize('lg'),
                 },
                 '> div': {
-                  marginTop: theme('spacing.10'),
-                  marginBottom: 0,
+                  marginTop: 0,
+                  marginBottom: theme('spacing.8'),
                   fontSize: fontSize('lg'),
                 },
                 a: {
-                  color: theme('colors.black'),
                   textDecoration: 'none',
                 },
                 strong: {
-                  color: theme('colors.black'),
                   fontWeight: theme('fontWeight.medium'),
                 },
                 hr: {
-                  marginTop: theme('spacing.10'),
-                  marginBottom: theme('spacing.10'),
-                  borderColor: theme('colors.gray.200'),
+                  marginTop: theme('spacing.8'),
+                  marginBottom: theme('spacing.16'),
                 },
                 pre: {
-                  // TODO: remove important
-                  backgroundColor: `${theme('colors.gray.100')} !important`,
-                  color: `${theme('colors.gray.800')} !important`,
+                  marginTop: 0,
+                  marginBottom: theme('spacing.8'),
                   padding: theme('spacing.8'),
                   borderRadius: theme('borderRadius.lg'),
 
@@ -129,18 +126,16 @@ module.exports = {
                     gridColumn: '2 / span 10',
                   },
                 },
-                'pre code': {
-                  color: `${theme('colors.gray.800')} !important`,
-                },
-                code: {
-                  color: theme('colors.gray.800'),
-                },
                 ul: {
-                  marginTop: theme('spacing.10'),
-                  marginBottom: 0,
+                  marginTop: 0,
+                  marginBottom: theme('spacing.8'),
+                },
+                ol: {
+                  marginTop: 0,
+                  marginBottom: theme('spacing.8'),
                 },
                 'h1, h2, h3, h4, h5, h6': {
-                  color: theme('colors.black'),
+                  marginTop: 0,
                   marginBottom: 0,
                   fontWeight: theme('fontWeight.normal'),
 
@@ -148,47 +143,83 @@ module.exports = {
                     fontWeight: theme('fontWeight.medium'),
                   },
                 },
-                'h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *': {
-                  marginTop: theme('spacing.10'),
-                },
                 // tailwind doesn't stick to this property order, so we can't make 'h3' overrule 'h2, h3, h4'
                 'h1, h2': {
                   fontSize: fontSize('2xl'),
-                  marginTop: theme('spacing.32'),
+                  marginTop: theme('spacing.20'),
+                  marginBottom: theme('spacing.10'),
                   [`@media (min-width: ${theme('screens.lg')})`]: {
                     fontSize: fontSize('3xl'),
                   },
                 },
                 h3: {
                   fontSize: fontSize('xl'),
-                  marginTop: theme('spacing.24'),
+                  marginTop: theme('spacing.16'),
+                  marginBottom: theme('spacing.10'),
                   [`@media (min-width: ${theme('screens.lg')})`]: {
                     fontSize: fontSize('2xl'),
                   },
                 },
                 'h4, h5, h6': {
                   fontSize: fontSize('lg'),
-                  marginTop: theme('spacing.10'),
                   [`@media (min-width: ${theme('screens.lg')})`]: {
                     fontSize: fontSize('xl'),
                   },
                 },
                 img: {
-                  borderRadius: theme('borderRadius.lg'),
                   // images are wrapped in <p>, which already has margin
                   marginTop: 0,
                   marginBottom: 0,
+                  borderRadius: theme('borderRadius.lg'),
                 },
                 blockquote: {
-                  color: theme('colors.gray.500'),
-                  backgroundColor: theme('colors.gray.100'),
                   fontWeight: theme('fontWeight.normal'),
                   border: 'none',
                   borderRadius: theme('borderRadius.lg'),
                   padding: theme('spacing.8'),
-                },
-                'blockquote > :first-child': {
                   marginTop: 0,
+                  marginBottom: theme('spacing.10'),
+                },
+                'blockquote > :last-child': {
+                  marginBottom: 0,
+                },
+              },
+            ],
+          },
+          // use prose-light instead of default, so it's easier to see theme differences
+          light: {
+            css: [
+              {
+                color: theme('colors.gray.500'),
+                a: {
+                  color: theme('colors.black'),
+                },
+                strong: {
+                  color: theme('colors.black'),
+                },
+                hr: {
+                  borderColor: theme('colors.gray.200'),
+                },
+                pre: {
+                  // TODO: remove important
+                  backgroundColor: `${theme('colors.gray.100')} !important`,
+                  color: `${theme('colors.gray.800')} !important`,
+                },
+                'pre code': {
+                  color: `${theme('colors.gray.800')} !important`,
+                },
+                code: {
+                  color: theme('colors.gray.800'),
+                },
+                'h1, h2, h3, h4, h5, h6': {
+                  color: theme('colors.black'),
+                },
+                blockquote: {
+                  color: theme('colors.gray.500'),
+                  backgroundColor: theme('colors.gray.100'),
+                },
+                'thead, tbody tr': {
+                  borderBottomColor: theme('colors.gray.200'),
                 },
               },
             ],
@@ -223,6 +254,9 @@ module.exports = {
                 blockquote: {
                   color: theme('colors.blueGray.500'),
                   backgroundColor: theme('colors.gray.800'),
+                },
+                'thead, tbody tr': {
+                  borderBottomColor: theme('colors.gray.600'),
                 },
               },
             ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,6 +75,115 @@ module.exports = {
         '-135': '-135deg',
         135: '135deg',
       },
+
+      typography: theme => {
+        return {
+          DEFAULT: {
+            css: [
+              {
+                color: theme('colors.gray.500'),
+                '> *': {
+                  gridColumn: '1 / -1',
+
+                  [`@media (min-width: ${theme('screens.lg')})`]: {
+                    gridColumn: '3 / span 8',
+                  },
+                },
+                p: {
+                  marginTop: theme('spacing.10'),
+                  marginBottom: 0,
+                  fontSize: theme('fontSize.lg.0'),
+                },
+                a: {
+                  color: theme('colors.black'),
+                  textDecoration: 'none',
+                },
+                strong: {
+                  color: theme('colors.black'),
+                  fontWeight: theme('fontWeight.medium'),
+                },
+                code: {
+                  color: theme('colors.gray.800'),
+                },
+                ul: {
+                  marginTop: theme('spacing.10'),
+                  marginBottom: 0,
+                },
+                'h1, h2, h3, h4, h5, h6': {
+                  color: theme('colors.black'),
+                  marginBottom: 0,
+                  fontWeight: theme('fontWeight.normal'),
+
+                  [`@media (min-width: ${theme('screens.lg')})`]: {
+                    fontWeight: theme('fontWeight.medium'),
+                  },
+                },
+                'h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *': {
+                  marginTop: theme('spacing.10'),
+                },
+                // tailwind doesn't stick to this property order, so we can't make 'h3' overrule 'h2, h3, h4'
+                'h1, h2': {
+                  fontSize: theme('fontSize.2xl.0'),
+                  marginTop: theme('spacing.32'),
+                  [`@media (min-width: ${theme('screens.lg')})`]: {
+                    fontSize: theme('fontSize.3xl.0'),
+                  },
+                },
+                h3: {
+                  fontSize: theme('fontSize.xl.0'),
+                  marginTop: theme('spacing.24'),
+                  [`@media (min-width: ${theme('screens.lg')})`]: {
+                    fontSize: theme('fontSize.2xl.0'),
+                  },
+                },
+                'h4, h5, h6': {
+                  fontSize: theme('fontSize.lg.0'),
+                  marginTop: theme('spacing.10'),
+                  [`@media (min-width: ${theme('screens.lg')})`]: {
+                    fontSize: theme('fontSize.xl.0'),
+                  },
+                },
+                img: {
+                  borderRadius: theme('borderRadius.lg'),
+                  // images are wrapped in <p>, which already has margin
+                  marginTop: 0,
+                  marginBottom: 0,
+                },
+                blockquote: {
+                  color: theme('colors.gray.800'),
+                  fontWeight: theme('fontWeight.normal'),
+                },
+                'blockquote > p:first-child': {
+                  marginTop: 0,
+                },
+              },
+            ],
+          },
+          dark: {
+            css: [
+              {
+                color: theme('colors.blueGray.500'),
+
+                a: {
+                  color: theme('colors.white'),
+                },
+                strong: {
+                  color: theme('colors.white'),
+                },
+                code: {
+                  color: theme('colors.gray.100'),
+                },
+                'h1, h2, h3, h4, h5, h6': {
+                  color: theme('colors.white'),
+                },
+                blockquote: {
+                  color: theme('colors.blueGray.500'),
+                },
+              },
+            ],
+          },
+        }
+      },
     },
   },
   purge: {


### PR DESCRIPTION
I've added some typography (prose) styles to `tailwind.config.js` so we control blog styles through prose. This felt better than providing custom components to the mdx parser. Prose for blogs, utility classes for everything else.

I've also fixed a small typo in the `KCDMdxComponent.components` prop, and I've removed the row-gap from the grid component. The column-gap works great, but the row-gap was only standing in the way.

I'm not done yet. I need to add a few more element types, and I'm chatting with the designer about some details. So

<p align="center">
to be continued
</p>

## TODO

- [ ] fix candy-dispenser `/blog/usememo-and-usecallback`
- [ ] what to do with the transparent `png` at `/blog/unit-vs-integration-vs-e2e-tests` ?