### PR TITLE
various optimizations to code blocks

### DIFF
--- a/styles/prose.css
+++ b/styles/prose.css
@@ -60,6 +60,11 @@ pre {
   content: attr(data-diff-line-number);
 }
 
+.prose pre > code {
+  display: inline-block;
+  min-width: 100%;
+}
+
 .codeblock-line {
   display: block;
   position: relative;

--- a/styles/prose.css
+++ b/styles/prose.css
@@ -50,9 +50,19 @@ pre {
   content: attr(data-line-number);
   text-align: right;
   display: inline-block;
-  width: 2rem;
+  width: 3.5rem;
   color: var(--base03);
-  margin-right: 1.5rem;
+  padding-right: 1.5rem;
+  position: sticky;
+  left: 0;
+  background-color: var(--base00);
+}
+
+.prose
+  pre[data-line-numbers='true']:not([data-lang='sh'])
+  [data-line-number]:before
+  .codeblock-line[data-highlight='true']:before {
+  background: var(--base0E);
 }
 
 .prose pre[data-add]:not([data-lang='sh']) [data-diff-line-number]:before,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -124,10 +124,15 @@ module.exports = {
                   backgroundColor: 'var(--base00)',
                   marginTop: 0,
                   marginBottom: theme('spacing.8'),
+                  marginLeft: `-${theme('spacing.10vw')}`,
+                  marginRight: `-${theme('spacing.10vw')}`,
                   padding: theme('spacing.8'),
-                  borderRadius: theme('borderRadius.lg'),
+                  borderRadius: 0,
 
                   [`@media (min-width: ${theme('screens.lg')})`]: {
+                    marginLeft: 0,
+                    marginRight: 0,
+                    borderRadius: theme('borderRadius.lg'),
                     gridColumn: '2 / span 10',
                   },
                 },


### PR DESCRIPTION
Improved the highlighted code blocks:

- code blocks now span full screen width on narrow screens (`< screen:lg`)
- highlighted lines are now extended to the full frame width, also when horizontally overflown
- line numbers are now sticky, so that they'll remain visible when scrolling horizontally