### PR TITLE
feat: implement workshops page

### DIFF
--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -15,8 +15,7 @@ function Button({
     <button
       {...buttonProps}
       className={clsx(
-        'inline-flex items-center px-11 py-6 whitespace-nowrap text-lg font-medium rounded-full opacity-100 disabled:opacity-50 space-x-5 transition',
-        'focus:outline-none ring-team-current dark:ring-offset-gray-900 ring-offset-white ring-offset-4 focus:ring-2',
+        'focus-ring inline-flex items-center px-11 py-6 whitespace-nowrap text-lg font-medium rounded-full opacity-100 disabled:opacity-50 space-x-5 transition',
         {
           'border-2 dark:border-gray-600 border-gray-200 text-black dark:text-white':
             variant === 'secondary',

--- a/app/components/form-elements.tsx
+++ b/app/components/form-elements.tsx
@@ -13,7 +13,7 @@ function Input(props: JSX.IntrinsicElements['input']) {
   return (
     <input
       {...props}
-      className="placeholder-gray-500 dark:disabled:text-blueGray-500 px-11 py-8 w-full text-black disabled:text-gray-400 dark:text-white text-lg font-medium bg-gray-200 dark:bg-gray-800 rounded-lg focus:outline-none ring-team-current dark:ring-offset-gray-900 ring-offset-white ring-offset-4 focus:ring-2"
+      className="placeholder-gray-500 dark:disabled:text-blueGray-500 focus-ring px-11 py-8 w-full text-black disabled:text-gray-400 dark:text-white text-lg font-medium bg-gray-200 dark:bg-gray-800 rounded-lg"
     />
   )
 }

--- a/app/components/tag.tsx
+++ b/app/components/tag.tsx
@@ -16,7 +16,7 @@ function Tag({tag, selected, onClick}: TagProps) {
         checked={selected}
         onChange={onClick}
         className={clsx(
-          'relative block mb-4 mr-4 px-6 py-3 w-auto h-auto rounded-full focus-within:outline-none transition hover:ring-2 focus-within:ring-2 ring-team-current ring-offset-4 dark:ring-offset-gray-900 ring-offset-white',
+          'focus-ring relative block mb-4 mr-4 px-6 py-3 w-auto h-auto rounded-full',
           {
             'text-black dark:text-white bg-gray-100 dark:bg-gray-800':
               !selected,

--- a/app/components/tag.tsx
+++ b/app/components/tag.tsx
@@ -16,7 +16,7 @@ function Tag({tag, selected, onClick}: TagProps) {
         checked={selected}
         onChange={onClick}
         className={clsx(
-          'relative block mb-4 mr-4 px-6 py-3 w-auto h-auto rounded-full focus-within:outline-none transition ring-gray-200 dark:ring-gray-600 dark:ring-offset-gray-900 ring-offset-white ring-offset-4 hover:ring-2 focus-within:ring-2',
+          'relative block mb-4 mr-4 px-6 py-3 w-auto h-auto rounded-full focus-within:outline-none transition hover:ring-2 focus-within:ring-2 ring-team-current ring-offset-4 dark:ring-offset-gray-900 ring-offset-white',
           {
             'text-black dark:text-white bg-gray-100 dark:bg-gray-800':
               !selected,

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -184,11 +184,10 @@ function TeamOption({team: value, error, selected}: TeamOptionProps) {
   return (
     <div
       className={clsx(
-        'relative col-span-full mb-3 bg-gray-100 dark:bg-gray-800 rounded-lg focus-within:outline-none ring-team-current ring-offset-4 focus-within:ring-2 lg:col-span-4 lg:mb-0',
+        'focus-ring relative col-span-full mb-3 bg-gray-100 dark:bg-gray-800 rounded-lg lg:col-span-4 lg:mb-0',
         team.focusClassName,
         {
-          'ring-2 ring-offset-team-current': selected,
-          'dark:ring-offset-gray-900 ring-offset-white': !selected,
+          'ring-2': selected,
         },
       )}
     >

--- a/app/routes/workshops/index.tsx
+++ b/app/routes/workshops/index.tsx
@@ -5,6 +5,13 @@ import {
   getMdxPagesInDirectory,
   mapFromMdxPageToMdxListItem,
 } from '../../utils/mdx'
+import {Grid} from '../../components/grid'
+import {images} from '../../images'
+import {H2, H3, H6, Paragraph} from '../../components/typography'
+import {Tag} from '../../components/tag'
+import {CourseSection} from '../../components/sections/course-section'
+import {useState} from 'react'
+import formatDate from 'date-fns/format'
 
 type LoaderData = {
   workshops: Array<MdxListItem>
@@ -27,26 +34,134 @@ export function meta() {
   }
 }
 
+function truncate(text: string, length: number) {
+  if (!text || text.length <= length) {
+    return text
+  }
+
+  return `${text.substr(0, length).trim()}…`
+}
+
+function WorkshopCard({
+  slug,
+  frontmatter: {
+    date,
+    title = 'Untitled Workshop',
+    description = 'Description TBA',
+    tech,
+  },
+}: MdxListItem) {
+  return (
+    <Link
+      to={slug}
+      className="focus-ring block flex flex-col p-16 pr-24 w-full h-full bg-gray-100 dark:bg-gray-800 rounded-lg"
+    >
+      <div className="flex-none h-36">
+        {/* TODO: how to determine if it's open or not? */}
+        {Math.random() * 10 < 5 ? (
+          <div className="inline-flex items-baseline">
+            <div className="block flex-none w-3 h-3 bg-green-600 rounded-full" />
+            <H6 as="p" className="pl-4">
+              Open for registration
+            </H6>
+          </div>
+        ) : null}
+      </div>
+      <div className="flex-none">
+        <div className="inline-block mb-4 px-8 py-4 text-black dark:text-white text-lg dark:bg-gray-600 bg-white rounded-full">
+          {tech}
+        </div>
+      </div>
+      <H3 className="flex-none mb-3">{title}</H3>
+      {/*TODO: line-clamp has a browser support of 90%, is that enough?*/}
+      <div className="flex-auto mb-10">
+        <Paragraph className="line-clamp-3">
+          {/*
+            We do use css line-clamp, this is for the 10% of the browsers that
+            don't support that. Don't focus too much at perfection. It's important
+            that the truncated string remains longer than the line-clamp, so that
+            line-clamp precedes for the 90% supporting that.
+          */}
+          {truncate(description, 120)}
+        </Paragraph>
+      </div>
+      {/*
+        TODO: design shows different date format, but that wraps really quickly.
+         I think we can move the time with timezone to the details page?
+      */}
+      <H6 className="flex flex-wrap">
+        {date ? formatDate(new Date(date), 'PPP') : 'To be announced'}
+      </H6>
+    </Link>
+  )
+}
+
+const ALL_TECHS = ['javascript', 'react', 'testing']
+
 function WorkshopsHome() {
   const data = useRouteData<LoaderData>()
+  // TODO: save state in url, like the filters on the blog?
+  const [selectedTech, setSelectedTech] = useState<string>('')
+  const workshops = selectedTech
+    ? data.workshops.filter(x => x.frontmatter.tech === selectedTech)
+    : data.workshops
+
   return (
     <div>
-      <header>
-        <h2>Kent C. Dodds</h2>
-      </header>
-      <main>
-        {data.workshops.map(workshop => (
-          <p key={workshop.slug}>
-            <Link to={`/workshops/${workshop.slug}`}>
-              {workshop.frontmatter.title ?? 'Untitled Workshop'}
-            </Link>
-            <br />
-            <small>
-              {workshop.frontmatter.description ?? 'Description TBA'}
-            </small>
-          </p>
+      <Grid className="grid-rows-max-content mb-36 mt-16">
+        <div className="col-span-full lg:col-span-6 lg:col-start-7 lg:row-span-2">
+          <img
+            className="object-cover"
+            src={images.teslaX.src}
+            alt={images.teslaX.alt}
+          />
+        </div>
+
+        <div className="col-span-full lg:col-span-6 lg:row-start-1">
+          <div className="space-y-2 lg:max-w-sm">
+            <H2>Check out these remote workshops.</H2>
+            <H2 variant="secondary" as="p">
+              See our upcoming events below.
+            </H2>
+          </div>
+        </div>
+      </Grid>
+
+      <Grid className="mb-14">
+        <div className="flex flex-wrap col-span-full -mb-4 -mr-4 lg:col-span-10">
+          {ALL_TECHS.map(tech => (
+            <Tag
+              key={tech}
+              tag={tech}
+              selected={selectedTech === tech}
+              onClick={() =>
+                selectedTech === tech
+                  ? setSelectedTech('')
+                  : setSelectedTech(tech)
+              }
+            />
+          ))}
+        </div>
+      </Grid>
+
+      <Grid className="mb-64">
+        <H6 className="col-span-full mb-6">
+          {selectedTech
+            ? `${workshops.length} workshops found`
+            : 'Showing all workshops'}
+        </H6>
+
+        {workshops.map(workshop => (
+          <div
+            key={workshop.slug}
+            className="col-span-full mb-4 md:col-span-4 lg:mb-6"
+          >
+            <WorkshopCard {...workshop} />
+          </div>
         ))}
-      </main>
+      </Grid>
+
+      <CourseSection />
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "^0.17.5",
+        "@tailwindcss/line-clamp": "^0.2.1",
         "@testing-library/cypress": "^7.0.6",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
@@ -4035,6 +4036,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz",
       "integrity": "sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA==",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.2.1.tgz",
+      "integrity": "sha512-Hq2KJY1+T2v7jw/mnT3mnC7CKbp5kj1XTqzSb2xbEt1j+JkxIR6N3ijsN/WevZtsKJfVE1KOejA/3IRKuhZEsQ==",
+      "dev": true,
       "peerDependencies": {
         "tailwindcss": ">=2.0.0"
       }
@@ -25320,6 +25330,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz",
       "integrity": "sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA=="
+    },
+    "@tailwindcss/line-clamp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.2.1.tgz",
+      "integrity": "sha512-Hq2KJY1+T2v7jw/mnT3mnC7CKbp5kj1XTqzSb2xbEt1j+JkxIR6N3ijsN/WevZtsKJfVE1KOejA/3IRKuhZEsQ==",
+      "dev": true
     },
     "@tailwindcss/typography": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   },
   "devDependencies": {
     "@remix-run/dev": "^0.17.5",
+    "@tailwindcss/line-clamp": "^0.2.1",
     "@testing-library/cypress": "^7.0.6",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",

--- a/styles/app.css
+++ b/styles/app.css
@@ -15,6 +15,7 @@
   --color-gray-900: #1f2028;
   --color-green-100: #e7f9ed;
   --color-green-500: #30c85e;
+  --color-green-600: #68d94a;
   --color-red-500: #ff4545;
   --color-yellow-500: #ffd644;
 

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -27,6 +27,6 @@
 
 @layer utilities {
   .focus-ring {
-    @apply focus:outline-none transition hover:ring-2 focus:ring-2 hover:ring-team-current focus:ring-team-current ring-transparent ring-offset-4 dark:ring-offset-gray-900 ring-offset-white;
+    @apply focus:outline-none focus-within:outline-none transition disabled:ring-0 hover:ring-2 focus:ring-2 focus-within:ring-2 hover:ring-team-current focus:ring-team-current focus-within:ring-team-current ring-offset-4 dark:ring-offset-gray-900 ring-offset-white;
   }
 }

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -24,3 +24,9 @@
   font-style: normal;
   font-display: swap;
 }
+
+@layer utilities {
+  .focus-ring {
+    @apply focus:outline-none transition hover:ring-2 focus:ring-2 hover:ring-team-current focus:ring-team-current ring-transparent ring-offset-4 dark:ring-offset-gray-900 ring-offset-white;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,15 +42,16 @@ module.exports = {
         500: 'var(--color-yellow-500)',
       },
       blue: {
-        500: 'var(--color-blue-500)',
         100: 'var(--color-blue-100)',
+        500: 'var(--color-blue-500)',
       },
       red: {
         500: 'var(--color-red-500)',
       },
       green: {
-        500: 'var(--color-green-500)',
         100: 'var(--color-green-100)',
+        500: 'var(--color-green-500)',
+        600: 'var(--color-green-600)',
       },
     },
 
@@ -268,5 +269,6 @@ module.exports = {
   plugins: [
     require('@tailwindcss/typography'),
     require('@tailwindcss/aspect-ratio'),
+    require('@tailwindcss/line-clamp'),
   ],
 }


### PR DESCRIPTION
Polished the `/workshops` page

I've also added the `focus-ring` css utility and applied it to a few existing places. This utility replaces various hover & focus utilities with a single className. I'll probably do this with a few more things over the next few PR's, as abstractions will become clearer.