### PR TITLE
fix: resolve all heading order violations

### DIFF
--- a/app/components/article-card.tsx
+++ b/app/components/article-card.tsx
@@ -33,9 +33,9 @@ function ArticleCard({
         <div className="mt-8 text-blueGray-500 text-xl font-medium">
           {formatDate(parseISO(date), 'PPP')} — {readTime?.text ?? 'quick read'}
         </div>
-        <div className="mt-4">
-          <H3>{title}</H3>
-        </div>
+        <H3 as="div" className="mt-4">
+          {title}
+        </H3>
       </a>
 
       <button className="absolute left-6 top-6 p-4 text-black whitespace-nowrap text-lg font-medium hover:bg-gray-200 focus:bg-gray-200 bg-white rounded-lg focus:outline-none shadow hover:shadow-lg focus:shadow-lg peer-hover:opacity-100 hover:opacity-100 peer-focus:opacity-100 focus:opacity-100 transition lg:px-8 lg:py-4 lg:opacity-0">

--- a/app/components/course-card.tsx
+++ b/app/components/course-card.tsx
@@ -21,7 +21,7 @@ function CourseCard({
   return (
     <div className="relative pt-12 w-full h-full">
       <div className="relative block pb-10 pt-36 px-8 w-full h-full bg-gray-100 dark:bg-gray-800 rounded-lg md:pb-20 md:px-16">
-        <H2>{title}</H2>
+        <H2 as="h3">{title}</H2>
         <div className="mt-4 max-w-sm">
           <H2 variant="secondary" as="p">
             {description}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -17,7 +17,7 @@ function NewsletterSection() {
   const user = useOptionalUser()
   return (
     <div>
-      <H6>Stay up to date</H6>
+      <H6 as="div">Stay up to date</H6>
       <div className="mt-4 max-w-md">
         <Paragraph>
           Subscribe to the newsletter to stay up to date with articles, courses
@@ -59,7 +59,7 @@ function NewsletterSection() {
 function ContactSection() {
   return (
     <div>
-      <H6>Contact</H6>
+      <H6 as="div">Contact</H6>
       <ul className="mt-4">
         <FooterLink name="contact page" href="/contact" />
         <FooterLink name="office hours" href="/office-hours" />
@@ -71,7 +71,7 @@ function ContactSection() {
 function GeneralSection() {
   return (
     <div>
-      <H6>General</H6>
+      <H6 as="div">General</H6>
       <ul className="mt-4">
         <FooterLink name="privacy policy" href="/privacy" />
         <FooterLink name="terms of use" href="/terms" />
@@ -84,7 +84,7 @@ function GeneralSection() {
 function SitemapSection() {
   return (
     <div>
-      <H6>Sitemap</H6>
+      <H6 as="div">Sitemap</H6>
       <ul className="mt-4">
         <FooterLink name="home" href="/legal/terms" />
         <FooterLink name="blog" href="/legal/privacy" />
@@ -102,7 +102,7 @@ function SitemapSection() {
 function AboutSection() {
   return (
     <div>
-      <H4 as="h6">Kent C. Dodds</H4>
+      <H4 as="div">Kent C. Dodds</H4>
 
       <p className="mt-6 max-w-md dark:text-blueGray-500 text-gray-500 text-2xl">
         Full time educator teaching people development

--- a/app/components/numbered-panel.tsx
+++ b/app/components/numbered-panel.tsx
@@ -11,7 +11,7 @@ function NumberedPanel({number, caption, description}: NumberedPanelProps) {
   // Note, we can move the counters to pure css if needed, but I'm not sure if it adds anything
   return (
     <li>
-      <H6 className="relative mb-6 lg:mb-8">
+      <H6 as="h3" className="relative mb-6 lg:mb-8">
         <span className="block mb-4 lg:absolute lg:-left-16 lg:mb-0">
           {number.toString().padStart(2, '0')}.
         </span>

--- a/app/components/sections/featured-section.tsx
+++ b/app/components/sections/featured-section.tsx
@@ -30,8 +30,10 @@ function FeaturedSection({
           <Grid className="lg:dark:bg-gray-800 pb-6 pt-14 rounded-lg md:pb-12 lg:bg-gray-100">
             <div className="col-span-full lg:flex lg:flex-col lg:col-span-5 lg:col-start-2 lg:justify-between">
               <div>
-                <H6>{caption}</H6>
-                <H2 className="mt-12">{title}</H2>
+                <H6 as="h2">{caption}</H6>
+                <H2 as="h3" className="mt-12">
+                  {title}
+                </H2>
 
                 <div className="mt-6 text-blueGray-500 text-xl font-medium">
                   {subTitle}

--- a/app/components/sections/hero-section.tsx
+++ b/app/components/sections/hero-section.tsx
@@ -79,7 +79,7 @@ function HeroSection({
         )}
       >
         <div className="flex flex-auto flex-col">
-          <H2>{title}</H2>
+          <H2 as="p">{title}</H2>
           {subtitle ? (
             <H2 as="p" variant="secondary" className="mt-3">
               {subtitle}

--- a/app/components/sections/testimonial-section.tsx
+++ b/app/components/sections/testimonial-section.tsx
@@ -46,7 +46,9 @@ function TestimonialSection({
             },
           )}
         >
-          <H4 className="mb-24">“{testimonial.testimonial}”</H4>
+          <H4 as="p" className="mb-24">
+            “{testimonial.testimonial}”
+          </H4>
           <div className="flex items-center">
             <img
               src={testimonial.imageUrl}

--- a/app/components/video-card.tsx
+++ b/app/components/video-card.tsx
@@ -24,9 +24,9 @@ function VideoCard({title, description, imageAlt, imageUrl}: VideoCardProps) {
           <PlayIcon />
         </div>
       </div>
-      <div className="mt-8">
-        <H5>{title}</H5>
-      </div>
+      <H5 as="h3" className="mt-8">
+        {title}
+      </H5>
       <p className="text-blueGray-500 text-xl">{description}</p>
     </div>
   )

--- a/app/components/workshop-card.tsx
+++ b/app/components/workshop-card.tsx
@@ -43,7 +43,9 @@ function WorkshopCard({
           {tech}
         </div>
       </div>
-      <H3 className="flex-none mb-3">{title}</H3>
+      <H3 as="div" className="flex-none mb-3">
+        {title}
+      </H3>
 
       <div className="flex-auto mb-10">
         <Paragraph className="line-clamp-3">
@@ -56,7 +58,7 @@ function WorkshopCard({
           {truncate(description, 120)}
         </Paragraph>
       </div>
-      <H6 className="flex flex-wrap">
+      <H6 as="div" className="flex flex-wrap">
         {date ? formatDate(new Date(date), 'PPP') : 'To be announced'}
       </H6>
     </Link>

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -36,10 +36,10 @@ function AboutIndex() {
 
       <Grid className="mb-24 mt-16 lg:mb-48">
         <div className="col-span-full mb-12 lg:col-span-4 lg:mb-0">
-          <H6>How I got where we are now.</H6>
+          <H6 as="h2">How I got where we are now.</H6>
         </div>
         <div className="col-span-full mb-8 lg:col-span-8 lg:mb-20">
-          <H2 className="mb-8">
+          <H2 as="p" className="mb-8">
             I'm a software engineer and teacher. I was born in 1988 (you can do
             the math) and grew up in Idaho.
           </H2>
@@ -92,18 +92,24 @@ function AboutIndex() {
         <div className="col-span-full lg:col-span-5 lg:col-start-1 lg:row-start-1">
           <H2 className="mb-10">Here are some of the values I live by.</H2>
 
-          <H6 className="mb-4">Here will go the first value</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the first value
+          </H6>
           <Paragraph className="mb-12">
             Praesent eu lacus odio. Pellentesque vitae lectus tortor. Donec elit
             nunc, dictum quis condimentum in, impe rdiet at arcu.
           </Paragraph>
-          <H6 className="mb-4">Here will go the second value.</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the second value.
+          </H6>
           <Paragraph className="mb-12">
             Mauris auctor nulla at felis placerat, ut elementum urna commodo.
             Aenean et rutrum quam. Etiam odio massa, congue in orci nec, ornare
             suscipit sem aenean turpis.
           </Paragraph>
-          <H6 className="mb-4">Here will go the third value</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the third value
+          </H6>
           <Paragraph className="mb-12">
             Mauris auctor nulla at felis placerat, ut elementum urna commodo.
             Aenean et rutrum quam. Etiam odio massa, congue in orci nec, ornare

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -143,7 +143,7 @@ function ArticleFooter() {
     <Grid>
       <div className="flex flex-col col-span-full justify-between mb-12 pb-12 text-blueGray-500 text-lg font-medium border-b border-gray-600 lg:flex-row lg:col-span-8 lg:col-start-3 lg:pb-6">
         <div className="flex space-x-5">
-          <H6>Share article</H6>
+          <H6 as="h2">Share article</H6>
           {/* TODO: fix links */}
           <Link
             className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
@@ -183,7 +183,7 @@ function ArticleFooter() {
         />
       </div>
       <div className="lg:col-start:5 col-span-full lg:col-span-6">
-        <H6>Written by Kent C. Dodds</H6>
+        <H6 as="div">Written by Kent C. Dodds</H6>
         <Paragraph className="mb-12 mt-3">
           {`
 Kent C. Dodds is a JavaScript software engineer and teacher. He's taught

--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -172,7 +172,9 @@ function BlogHome() {
 
       {data.tags.length > 0 ? (
         <Grid className="mb-14">
-          <H6 className="col-span-full mb-6">Search blog by topics</H6>
+          <H6 as="div" className="col-span-full mb-6">
+            Search blog by topics
+          </H6>
           <div className="flex flex-wrap col-span-full -mb-4 -mr-4 lg:col-span-10">
             {data.tags.map(tag => (
               <Tag

--- a/app/routes/chats.$season.$episode.$slug.tsx
+++ b/app/routes/chats.$season.$episode.$slug.tsx
@@ -86,7 +86,7 @@ function Homework({
 }) {
   return (
     <div className="bg-secondary p-10 pb-16 w-full rounded-lg">
-      <H6 className="inline-flex items-center mb-8 space-x-4">
+      <H6 as="h4" className="inline-flex items-center mb-8 space-x-4">
         <ClipboardIcon />
         <span>Homework</span>
       </H6>
@@ -116,9 +116,9 @@ function Homework({
 function Resources({resources = []}: {resources: CWKEpisode['resources']}) {
   return (
     <div className="bg-secondary p-10 pb-16 rounded-lg">
-      <h6 className="text-primary inline-flex items-center mb-8 text-xl font-medium">
+      <h4 className="text-primary inline-flex items-center mb-8 text-xl font-medium">
         Resources
-      </h6>
+      </h4>
 
       <ul className="text-primary space-y-8">
         {resources.map(resource => (
@@ -139,6 +139,8 @@ function Resources({resources = []}: {resources: CWKEpisode['resources']}) {
 function Guests({episode}: {episode: CWKEpisode}) {
   return (
     <>
+      <h4 className="sr-only">Guests</h4>
+
       {episode.guests.map(guest => (
         <div
           key={guest.name}
@@ -150,9 +152,9 @@ function Guests({episode}: {episode: CWKEpisode}) {
             className="flex-none mb-6 mr-8 w-20 h-20 rounded-lg object-cover md:mb-0"
           />
           <div className="mb-6 w-full md:flex-auto md:mb-0">
-            <h6 className="text-primary mb-2 text-xl font-medium leading-none">
+            <div className="text-primary mb-2 text-xl font-medium leading-none">
               {guest.name}
-            </h6>
+            </div>
             <p className="text-xl leading-none">{guest.company}</p>
           </div>
           <div className="flex flex-none space-x-4">
@@ -183,9 +185,9 @@ function Transcript({
 
   return (
     <div className="bg-secondary col-span-full p-10 pb-16 rounded-lg">
-      <h6 className="text-primary inline-flex items-center mb-8 text-xl font-medium">
+      <h4 className="text-primary inline-flex items-center mb-8 text-xl font-medium">
         Transcript
-      </h6>
+      </h4>
 
       <div
         className={clsx(

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -121,7 +121,9 @@ function PodcastHome() {
       />
 
       <Grid className="mb-14">
-        <H6 className="col-span-full mb-6">Listen to the podcasts here</H6>
+        <H6 as="div" className="col-span-full mb-6">
+          Listen to the podcasts here
+        </H6>
 
         <div className="flex flex-wrap col-span-full items-start justify-start -mb-4 -mr-4 lg:col-span-10">
           <PodcastAppLink
@@ -203,7 +205,10 @@ function PodcastHome() {
 
         {currentSeason ? (
           <div className="flex flex-col col-span-full mb-6 lg:flex-row lg:justify-between lg:mb-12">
-            <H6 className="flex flex-col col-span-full mb-10 lg:flex-row lg:mb-0">
+            <H6
+              as="h2"
+              className="flex flex-col col-span-full mb-10 lg:flex-row lg:mb-0"
+            >
               <span>Chats with Kent C. Dodds</span>
               &nbsp;
               <span>{`Season ${currentSeason.seasonNumber} — ${currentSeason.episodes.length} episodes`}</span>

--- a/app/routes/chats/$season.tsx
+++ b/app/routes/chats/$season.tsx
@@ -53,12 +53,12 @@ export default function Screen() {
           alt={episode.title}
         />
         <div className="text-primary relative flex flex-col col-span-3 md:col-span-7 lg:flex-row lg:col-span-11 lg:items-center lg:justify-between">
-          <h4 className="mb-3 text-xl font-medium lg:mb-0">
+          <div className="mb-3 text-xl font-medium lg:mb-0">
             <span className="inline-block w-10 lg:text-lg">
               {`${episode.episodeNumber.toString().padStart(2, '0')}.`}
             </span>
             {episode.title}
-          </h4>
+          </div>
           <div className="text-gray-400 text-lg font-medium">
             {formatTime(episode.duration)}
           </div>

--- a/app/routes/courses/index.tsx
+++ b/app/routes/courses/index.tsx
@@ -58,16 +58,20 @@ function CoursesHome() {
 
       <Grid as="main" className="mb-48">
         <div className="hidden col-span-full mb-12 lg:block lg:col-span-4 lg:mb-0">
-          <H6>Reasons to invest in your career.</H6>
+          <H6 as="h2">Reasons to invest in your career.</H6>
         </div>
         <div className="col-span-full mb-8 lg:col-span-4 lg:mb-20">
-          <H6 className="mb-4">Become a more confident developer</H6>
+          <H6 as="h3" className="mb-4">
+            Become a more confident developer
+          </H6>
           <Paragraph className="mb-20">
             Praesent eu lacus odio. Pellentesque vitae lectus tortor. Donec elit
             nunc, dictum quis condimentum in, impe rdiet at arcu. Donec et nunc
             vel mas sa fringilla fermentum. Donec in orn are est doler sit amet.
           </Paragraph>
-          <H6 className="mb-4">Earn more money as a developer</H6>
+          <H6 as="h3" className="mb-4">
+            Earn more money as a developer
+          </H6>
           <Paragraph>
             Praesent eu lacus odio. Pellentesque vitae lectus tortor. Donec elit
             nunc, dictum quis condimentum in, imp erdiet at arcu.
@@ -77,6 +81,8 @@ function CoursesHome() {
           <ArrowButton direction="down" />
         </div>
       </Grid>
+
+      <h2 className="sr-only">Courses</h2>
 
       <Grid className="gap-y-4 mb-24 lg:mb-96">
         <div className="col-span-full lg:col-span-6">
@@ -180,7 +186,7 @@ function CoursesHome() {
         </div>
 
         <div className="col-span-full mt-4 lg:col-span-6 lg:col-start-7 lg:mt-0">
-          <H2 className="mb-8">
+          <H2 as="p" className="mb-8">
             Do you want to work trough one of these courses with peers?
           </H2>
           <H2 variant="secondary" as="p" className="mb-16">

--- a/app/routes/discord.tsx
+++ b/app/routes/discord.tsx
@@ -35,7 +35,7 @@ function CategoryCardContent({title, description, number}: CategoryCardProps) {
 
   return (
     <>
-      <H5 className="w-full">
+      <H5 as="div" className="w-full">
         <AccordionButton className="relative w-full text-left">
           <span className="absolute -left-16 top-0 flex hidden text-lg lg:block">
             {number.toString().padStart(2, '0')}.
@@ -160,18 +160,24 @@ export default function Discord() {
             Join Discord
           </ButtonLink>
 
-          <H6 className="mb-4">Here will go the first title..</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the first title..
+          </H6>
           <Paragraph className="mb-12">
             Praesent eu lacus odio. Pellentesque vitae lectus tortor. Donec elit
             nunc, dictum quis condimentum in, impe rdiet at arcu.{' '}
           </Paragraph>
-          <H6 className="mb-4">Here will go the second title..</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the second title..
+          </H6>
           <Paragraph className="mb-12">
             Mauris auctor nulla at felis placerat, ut elementum urna commodo.
             Aenean et rutrum quam. Etiam odio massa, congue in orci nec, ornare
             suscipit sem aenean turpis.
           </Paragraph>
-          <H6 className="mb-4">Here will go the third title.</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the third title.
+          </H6>
           <Paragraph className="mb-12">
             Mauris auctor nulla at felis placerat, ut elementum urna commodo.
             Aenean et rutrum quam. Etiam odio massa, congue in orci nec, ornare
@@ -223,10 +229,10 @@ export default function Discord() {
 
       <Grid className="mb-24 lg:mb-64">
         <div className="hidden col-span-full mb-12 lg:block lg:col-span-4 lg:mb-0">
-          <H6>Set up your own learning club.</H6>
+          <H6 as="h2">Set up your own learning club.</H6>
         </div>
         <div className="col-span-full mb-20 lg:col-span-8 lg:mb-28">
-          <H2 className="mb-3">
+          <H2 as="p" className="mb-3">
             Learning clubs in the discord are like study groups you put together
             yourself.
           </H2>
@@ -236,7 +242,7 @@ export default function Discord() {
           </H2>
         </div>
         <div className="col-span-full mb-8 lg:col-span-4 lg:col-start-5 lg:mb-0 lg:pr-12">
-          <H6 className="mb-4">
+          <H6 as="h3" className="mb-4">
             When we learn together, we learn better, and that's the idea.
           </H6>
           <Paragraph className="mb-16">
@@ -244,7 +250,7 @@ export default function Discord() {
             nunc, dictum quis condimentum in, imp erdiet at arcu.
           </Paragraph>
 
-          <H6 className="mb-4">
+          <H6 as="h3" className="mb-4">
             Develop friendships with other nice learners in the community.
           </H6>
           <Paragraph>
@@ -253,7 +259,7 @@ export default function Discord() {
           </Paragraph>
         </div>
         <div className="col-span-full lg:col-span-4 lg:col-start-9 lg:pr-12">
-          <H6 className="mb-4">
+          <H6 as="h3" className="mb-4">
             You have access to me (Kent) during twice-weekly office hours.
           </H6>
           <Paragraph className="mb-16">
@@ -261,7 +267,7 @@ export default function Discord() {
             nunc, dictum quis condimentum in, imp erdiet at arcu.
           </Paragraph>
 
-          <H6 className="mb-4">
+          <H6 as="h3" className="mb-4">
             You can chat with members of the KCD Community on Discord.
           </H6>
           <Paragraph>

--- a/app/routes/me.tsx
+++ b/app/routes/me.tsx
@@ -216,7 +216,7 @@ function YouScreen() {
                   src={TEAM_MAP[user.team].image()}
                   alt={TEAM_MAP[user.team].image.alt}
                 />
-                <H6>{TEAM_MAP[user.team].label}</H6>
+                <H6 as="span">{TEAM_MAP[user.team].label}</H6>
               </div>
             </div>
           </div>

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -194,7 +194,7 @@ function TeamOption({team: value, error, selected}: TeamOptionProps) {
           aria-describedby={error ? 'team-error' : undefined}
         />
         <img className="block mb-16" src={team.image()} alt={team.image.alt} />
-        <H6>{team.label}</H6>
+        <H6 as="span">{team.label}</H6>
       </label>
     </div>
   )
@@ -310,18 +310,24 @@ export default function NewAccount() {
         <div className="col-span-full lg:col-span-5 lg:col-start-8">
           <H2 className="mb-32">You might be thinking, why pick a team?</H2>
 
-          <H6 className="mb-4">Gamify your learning.</H6>
+          <H6 as="h3" className="mb-4">
+            Gamify your learning.
+          </H6>
           <Paragraph className="mb-12">
             Praesent eu lacus odio. Pellentesque vitae lectus tortor. Donec elit
             nunc, dictum quis condimentum in, impe rdiet at arcu.{' '}
           </Paragraph>
-          <H6 className="mb-4">Here will go the second title.</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the second title.
+          </H6>
           <Paragraph className="mb-12">
             Mauris auctor nulla at felis placerat, ut elementum urna commodo.
             Aenean et rutrum quam. Etiam odio massa, congue in orci nec, ornare
             suscipit sem aenean turpis.
           </Paragraph>
-          <H6 className="mb-4">Here will go the third title.</H6>
+          <H6 as="h3" className="mb-4">
+            Here will go the third title.
+          </H6>
           <Paragraph className="mb-12">
             Mauris auctor nulla at felis placerat, ut elementum urna commodo.
             Aenean et rutrum quam. Etiam odio massa, congue in orci nec, ornare

--- a/app/routes/workshops/index.tsx
+++ b/app/routes/workshops/index.tsx
@@ -71,7 +71,7 @@ function WorkshopsHome() {
       </Grid>
 
       <Grid className="mb-64">
-        <H6 className="col-span-full mb-6">
+        <H6 as="h2" className="col-span-full mb-6">
           {selectedTech
             ? `${workshops.length} workshops found`
             : 'Showing all workshops'}


### PR DESCRIPTION
Removed level skipping in headings, and removed some headings altogether. I've also added headings visible to screen-readers only above the guest listing on the podcast pages, and above the courses on the courses page.