### PR TITLE
feat: add redbox for server errors in dev env

### DIFF
--- a/app/components/errors.tsx
+++ b/app/components/errors.tsx
@@ -4,10 +4,66 @@ import {images} from '../images'
 import {articles} from '../utils/temp.fixtures'
 import {HeroSection} from './sections/hero-section'
 import {BlogSection} from './sections/blog-section'
+import {H2, H6} from './typography'
+import errorStack from 'error-stack-parser'
+import clsx from 'clsx'
 
-function ErrorPage({title, subtitle}: {title: string; subtitle: string}) {
+function RedBox({error}: {error: Error}) {
+  const [isVisible, setIsVisible] = React.useState(true)
+  const frames = errorStack.parse(error)
+
   return (
-    <main>
+    <div
+      className={clsx(
+        'fixed z-10 inset-0 flex items-center justify-center transition',
+        {
+          'opacity-0 pointer-events-none': !isVisible,
+        },
+      )}
+    >
+      <button
+        className="absolute inset-0 block w-full h-full bg-black opacity-75"
+        onClick={() => setIsVisible(false)}
+      />
+      <div className="border-lg text-primary relative mx-5vw my-16 p-12 max-h-75vh bg-red-500 rounded-lg overflow-y-auto">
+        <H2>{error.message}</H2>
+        <div>
+          {frames.map(frame => (
+            <div
+              key={[frame.fileName, frame.lineNumber, frame.columnNumber].join(
+                '-',
+              )}
+              className="pt-4"
+            >
+              <H6 as="div" className="pt-2">
+                {frame.functionName}
+              </H6>
+              <div className="font-mono opacity-75">
+                {frame.fileName}:{frame.lineNumber}:{frame.columnNumber}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ErrorPage({
+  title,
+  subtitle,
+  error,
+}: {
+  title: string
+  subtitle: string
+  error?: Error
+}) {
+  return (
+    <main className="relative">
+      {error && process.env.NODE_ENV === 'development' ? (
+        <RedBox error={error} />
+      ) : null}
+
       <HeroSection
         title={title}
         subtitle={subtitle}
@@ -41,7 +97,7 @@ function FourOhFour() {
   )
 }
 
-function ServerError() {
+function ServerError({error}: {error?: Error}) {
   const matches = useMatches()
   const last = matches[matches.length - 1]
   const pathname = last?.pathname
@@ -50,6 +106,7 @@ function ServerError() {
     <ErrorPage
       title="500 - Oh no, something did not go that well."
       subtitle={`"${pathname}" is currently not working. So sorry.`}
+      error={error}
     />
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "compression": "^1.7.4",
         "date-fns": "^2.22.1",
         "dotenv": "^10.0.0",
+        "error-stack-parser": "^2.0.6",
         "express": "^4.17.1",
         "framer-motion": "^4.1.17",
         "hast-util-to-html": "^7.1.3",
@@ -8962,6 +8963,14 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "dependencies": {
+        "stackframe": "^1.1.1"
       }
     },
     "node_modules/es-abstract": {
@@ -20526,6 +20535,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
     "node_modules/start-server-and-test": {
       "version": "1.12.5",
       "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.12.5.tgz",
@@ -29688,6 +29702,14 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "es-abstract": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
@@ -38571,6 +38593,11 @@
           "dev": true
         }
       }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "start-server-and-test": {
       "version": "1.12.5",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "compression": "^1.7.4",
     "date-fns": "^2.22.1",
     "dotenv": "^10.0.0",
+    "error-stack-parser": "^2.0.6",
     "express": "^4.17.1",
     "framer-motion": "^4.1.17",
     "hast-util-to-html": "^7.1.3",


### PR DESCRIPTION
Improved the 500-error page by showing the error when in development mode. It's dismissable by clicking on the backdrop. 

I haven't tested, but due to the check on `NODE_ENV` it shouldn't appear in production mode.

https://user-images.githubusercontent.com/1196524/125967843-8e9e01d2-6670-4fc4-a995-0676defa4854.mp4

