### PR TITLE
feat: improve copy button

### DIFF
--- a/app/components/article-card.tsx
+++ b/app/components/article-card.tsx
@@ -3,7 +3,7 @@ import formatDate from 'date-fns/format'
 import parseISO from 'date-fns/parseISO'
 import type {MdxListItem} from 'types'
 import {H3} from './typography'
-import {CopyIcon} from './icons/copy-icon'
+import {ClipboardCopyButton} from './clipboard-copy-button'
 
 function ArticleCard({
   readTime,
@@ -16,6 +16,12 @@ function ArticleCard({
     bannerUrl,
   },
 }: MdxListItem) {
+  // TODO: fix this. We need to retrieve the origin at the server as well. Add an ROOT_URL env variable? Make full url part of front matter?
+  const articleUrl = new URL(
+    `/blog/${slug}`,
+    typeof location === 'undefined' ? 'http://example.com' : location.origin,
+  ).toString()
+
   return (
     <div className="relative w-full">
       <a
@@ -38,12 +44,10 @@ function ArticleCard({
         </H3>
       </a>
 
-      <button className="absolute left-6 top-6 p-4 text-black whitespace-nowrap text-lg font-medium hover:bg-gray-200 focus:bg-gray-200 bg-white rounded-lg focus:outline-none shadow hover:shadow-lg focus:shadow-lg peer-hover:opacity-100 hover:opacity-100 peer-focus:opacity-100 focus:opacity-100 transition lg:px-8 lg:py-4 lg:opacity-0">
-        <span className="hidden lg:inline">Click to copy url</span>
-        <span className="inline lg:hidden">
-          <CopyIcon />
-        </span>
-      </button>
+      <ClipboardCopyButton
+        value={articleUrl}
+        className="absolute left-6 top-6"
+      />
     </div>
   )
 }

--- a/app/components/article-card.tsx
+++ b/app/components/article-card.tsx
@@ -4,6 +4,7 @@ import parseISO from 'date-fns/parseISO'
 import type {MdxListItem} from 'types'
 import {H3} from './typography'
 import {ClipboardCopyButton} from './clipboard-copy-button'
+import {useRequestInfo} from '../utils/providers'
 
 function ArticleCard({
   readTime,
@@ -16,11 +17,8 @@ function ArticleCard({
     bannerUrl,
   },
 }: MdxListItem) {
-  // TODO: fix this. We need to retrieve the origin at the server as well. Add an ROOT_URL env variable? Make full url part of front matter?
-  const articleUrl = new URL(
-    `/blog/${slug}`,
-    typeof location === 'undefined' ? 'http://example.com' : location.origin,
-  ).toString()
+  const requestInfo = useRequestInfo()
+  const permalink = `${requestInfo.origin}/blog/${slug}`
 
   return (
     <div className="relative w-full">
@@ -45,7 +43,7 @@ function ArticleCard({
       </a>
 
       <ClipboardCopyButton
-        value={articleUrl}
+        value={permalink}
         className="absolute left-6 top-6"
       />
     </div>

--- a/app/components/clipboard-copy-button.tsx
+++ b/app/components/clipboard-copy-button.tsx
@@ -1,0 +1,87 @@
+import clsx from 'clsx'
+import * as React from 'react'
+import {CheckIcon} from './icons/check-icon'
+import {CopyIcon} from './icons/copy-icon'
+
+async function copyToClipboard(value: string) {
+  try {
+    if ('clipboard' in navigator) {
+      await navigator.clipboard.writeText(value)
+      return true
+    }
+
+    const element = document.createElement('textarea')
+    element.value = value
+    document.body.append(element)
+    element.select()
+    document.execCommand('copy')
+    element.remove()
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+interface ClipboardCopyButtonProps {
+  value: string
+  className?: string
+  variant?: 'responsive' | 'icon'
+}
+
+enum State {
+  Idle = 'idle',
+  Copy = 'copy',
+  Copied = 'copied',
+}
+
+function ClipboardCopyButton({
+  value,
+  className,
+  variant = 'responsive',
+}: ClipboardCopyButtonProps) {
+  const [state, setState] = React.useState<State>(State.Idle)
+
+  const transition = async () => {
+    switch (state) {
+      case State.Copy: {
+        const res = await copyToClipboard(value)
+        console.log('copied', res)
+        setState(State.Copied)
+        break
+      }
+      case State.Copied: {
+        setTimeout(() => {
+          setState(State.Idle)
+        }, 2000)
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  React.useEffect(() => {
+    void transition()
+  }, [state])
+
+  return (
+    <button
+      onClick={() => setState(State.Copy)}
+      className={clsx(
+        'p-3 text-black whitespace-nowrap text-lg font-medium hover:bg-gray-200 focus:bg-gray-200 bg-white rounded-lg focus:outline-none shadow hover:shadow-lg focus:shadow-lg group-hover:opacity-100 peer-hover:opacity-100 hover:opacity-100 peer-focus:opacity-100 focus:opacity-100 transition lg:opacity-0',
+        {'lg:px-8 lg:py-4': variant === 'responsive'},
+        className,
+      )}
+    >
+      <span className={clsx('hidden', {'lg:inline': variant === 'responsive'})}>
+        {state === State.Copied ? 'Copied to clipboard' : 'Click to copy url'}
+      </span>
+      <span className={clsx('inline', {'lg:hidden': variant === 'responsive'})}>
+        {state === State.Copied ? <CheckIcon /> : <CopyIcon />}
+      </span>
+    </button>
+  )
+}
+
+export {ClipboardCopyButton}

--- a/app/components/icons/check-circled-icon.tsx
+++ b/app/components/icons/check-circled-icon.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+
+function CheckCircledIcon({
+  size = 36,
+  className,
+}: {
+  size?: number
+  className?: string
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 36 36"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <circle cx="18" cy="18" r="18" fill="currentColor" />
+      <path
+        d="M10.8115 17L16.4214 22.6099L25.0314 14"
+        stroke="white"
+        strokeWidth="2"
+      />
+    </svg>
+  )
+}
+
+export {CheckCircledIcon}

--- a/app/components/icons/check-icon.tsx
+++ b/app/components/icons/check-icon.tsx
@@ -1,26 +1,14 @@
 import * as React from 'react'
 
-function CheckIcon({
-  size = 36,
-  className,
-}: {
-  size?: number
-  className?: string
-}) {
+function CheckIcon() {
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 36 36"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-    >
-      <circle cx="18" cy="18" r="18" fill="currentColor" />
+    <svg width="24" height="24" fill="none" viewBox="0 0 24 24">
       <path
-        d="M10.8115 17L16.4214 22.6099L25.0314 14"
-        stroke="white"
-        strokeWidth="2"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+        d="M5.75 12.8665L8.33995 16.4138C9.15171 17.5256 10.8179 17.504 11.6006 16.3715L18.25 6.75"
       />
     </svg>
   )

--- a/app/components/icons/copy-icon.tsx
+++ b/app/components/icons/copy-icon.tsx
@@ -2,24 +2,24 @@ import * as React from 'react'
 
 function CopyIcon() {
   return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
+    <svg width="24" height="24" fill="none" viewBox="0 0 24 24">
       <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M13.25 0H6.5C5.121 0 4 1.122 4 2.5C4 2.914 4.336 3.25 4.75 3.25C5.164 3.25 5.5 2.914 5.5 2.5C5.5 1.949 5.948 1.5 6.5 1.5H13.25C13.939 1.5 14.5 2.061 14.5 2.75V9.5C14.5 10.051 14.052 10.5 13.5 10.5C13.086 10.5 12.75 10.836 12.75 11.25C12.75 11.665 13.086 12 13.5 12C14.879 12 16 10.878 16 9.5V2.75C16 1.233 14.767 0 13.25 0Z"
-        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+        d="M6.5 15.25V15.25C5.5335 15.25 4.75 14.4665 4.75 13.5V6.75C4.75 5.64543 5.64543 4.75 6.75 4.75H13.5C14.4665 4.75 15.25 5.5335 15.25 6.5V6.5"
       />
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M10.5 13.25C10.5 13.939 9.939 14.5 9.25 14.5H2.75C2.061 14.5 1.5 13.939 1.5 13.25V6.75C1.5 6.061 2.061 5.5 2.75 5.5H9.25C9.939 5.5 10.5 6.061 10.5 6.75V13.25ZM9.25 4H2.75C1.233 4 0 5.234 0 6.75V13.25C0 14.767 1.233 16 2.75 16H9.25C10.767 16 12 14.767 12 13.25V6.75C12 5.234 10.767 4 9.25 4Z"
-        fill="currentColor"
+      <rect
+        width="10.5"
+        height="10.5"
+        x="8.75"
+        y="8.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+        rx="2"
       />
     </svg>
   )

--- a/app/components/sections/featured-section.tsx
+++ b/app/components/sections/featured-section.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import {Grid} from '../grid'
 import {H2, H6} from '../typography'
 import {ArrowLink} from '../arrow-button'
-import {CopyIcon} from '../icons/copy-icon'
+import {ClipboardCopyButton} from '../clipboard-copy-button'
 
 type FeaturedSectionProps = {
   caption?: string
@@ -11,6 +11,7 @@ type FeaturedSectionProps = {
   title?: string
   imageUrl?: string
   imageAlt?: string
+  showCopyButton?: boolean
 } & ({href?: never; slug: string} | {href: string; slug?: never})
 
 function FeaturedSection({
@@ -22,12 +23,13 @@ function FeaturedSection({
   imageAlt,
   title = 'Untitled Post',
   subTitle,
+  showCopyButton,
 }: FeaturedSectionProps) {
   return (
     <div className="px-8 w-full lg:px-0">
       <div className="lg:dark:bg-transparent bg-gray-100 dark:bg-gray-800 rounded-lg lg:bg-transparent">
         <div className="-mx-8 lg:mx-0">
-          <Grid className="lg:dark:bg-gray-800 pb-6 pt-14 rounded-lg md:pb-12 lg:bg-gray-100">
+          <Grid className="group lg:dark:bg-gray-800 pb-6 pt-14 rounded-lg md:pb-12 lg:bg-gray-100">
             <div className="col-span-full lg:flex lg:flex-col lg:col-span-5 lg:col-start-2 lg:justify-between">
               <div>
                 <H6 as="h2">{caption}</H6>
@@ -42,13 +44,10 @@ function FeaturedSection({
 
               <div className="flex items-center justify-between mt-12">
                 <ArrowLink to={slug ?? href ?? '/'}>{cta}</ArrowLink>
-                <button className="flex items-center justify-center w-12 h-12 text-gray-800 whitespace-nowrap bg-white rounded-lg lg:hidden">
-                  <CopyIcon />
-                </button>
               </div>
             </div>
 
-            <div className="col-span-full mt-12 lg:col-span-4 lg:col-start-8">
+            <div className="relative col-span-full mt-12 lg:col-span-4 lg:col-start-8">
               <div className="aspect-w-3 aspect-h-4 w-full">
                 <img
                   className="rounded-lg object-cover"
@@ -56,6 +55,14 @@ function FeaturedSection({
                   alt={imageAlt}
                 />
               </div>
+              {showCopyButton ? (
+                <ClipboardCopyButton
+                  className="absolute left-6 top-6"
+                  value={
+                    '/* TODO: fix me, slug & href do not hold full urls */'
+                  }
+                />
+              ) : null}
             </div>
           </Grid>
         </div>

--- a/app/components/sections/featured-section.tsx
+++ b/app/components/sections/featured-section.tsx
@@ -11,7 +11,7 @@ type FeaturedSectionProps = {
   title?: string
   imageUrl?: string
   imageAlt?: string
-  showCopyButton?: boolean
+  permalink?: string
 } & ({href?: never; slug: string} | {href: string; slug?: never})
 
 function FeaturedSection({
@@ -23,7 +23,7 @@ function FeaturedSection({
   imageAlt,
   title = 'Untitled Post',
   subTitle,
-  showCopyButton,
+  permalink,
 }: FeaturedSectionProps) {
   return (
     <div className="px-8 w-full lg:px-0">
@@ -55,12 +55,10 @@ function FeaturedSection({
                   alt={imageAlt}
                 />
               </div>
-              {showCopyButton ? (
+              {permalink ? (
                 <ClipboardCopyButton
                   className="absolute left-6 top-6"
-                  value={
-                    '/* TODO: fix me, slug & href do not hold full urls */'
-                  }
+                  value={permalink}
                 />
               ) : null}
             </div>

--- a/app/routes/404.tsx
+++ b/app/routes/404.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import {ErrorPage} from '../components/errors'
+import {HeroSection} from '../components/sections/hero-section'
+import {images} from '../images'
 
 export function meta() {
   return {title: "Ain't nothing here"}
@@ -7,9 +8,13 @@ export function meta() {
 
 export default function NotFoundPage() {
   return (
-    <ErrorPage
-      title="404 - Oh no, how did you get here?"
-      subtitle="This is not a page on kentcdodds.com. So sorry."
-    />
+    <main>
+      <HeroSection
+        title="404 - Oh no, you found a page that's missing stuff."
+        subtitle="This is not a page on kentcdodds.com. So sorry."
+        imageUrl={images.bustedOnewheel()}
+        imageAlt={images.bustedOnewheel.alt}
+      />
+    </main>
   )
 }

--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -205,6 +205,7 @@ function BlogHome() {
             caption="Featured article"
             cta="Read full article"
             slug={featured.slug}
+            showCopyButton
           />
         </div>
       ) : null}

--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -135,6 +135,10 @@ function BlogHome() {
   // TODO: determine featured posts using some smarts on the backend
   // based on the user's read posts etc.
   const featured = isSearching ? null : matchingPosts[0]
+  const featuredPermalink = featured
+    ? `${requestInfo.origin}/blog/${featured.slug}`
+    : undefined
+
   const posts = isSearching
     ? matchingPosts.slice(0, indexToShow)
     : postsToShow.slice(1, indexToShow)
@@ -205,7 +209,7 @@ function BlogHome() {
             caption="Featured article"
             cta="Read full article"
             slug={featured.slug}
-            showCopyButton
+            permalink={featuredPermalink}
           />
         </div>
       ) : null}

--- a/app/routes/chats.$season.$episode.$slug.tsx
+++ b/app/routes/chats.$season.$episode.$slug.tsx
@@ -10,7 +10,7 @@ import {H2, H3, H6, Paragraph} from '../components/typography'
 import {Grid} from '../components/grid'
 import {ArrowIcon} from '../components/icons/arrow-icon'
 import {ClipboardIcon} from '../components/icons/clipboard-icon'
-import {CheckIcon} from '../components/icons/check-icon'
+import {CheckCircledIcon} from '../components/icons/check-circled-icon'
 import {GithubIcon} from '../components/icons/github-icon'
 import {TwitterIcon} from '../components/icons/twitter-icon'
 import {PlusIcon} from '../components/icons/plus-icon'
@@ -97,7 +97,7 @@ function Homework({
             key={homeworkHTML}
             className="flex pb-12 pt-8 border-t border-gray-200 dark:border-gray-600"
           >
-            <CheckIcon
+            <CheckCircledIcon
               className="flex-none mr-6 text-gray-400 dark:text-gray-600"
               size={24}
             />

--- a/app/routes/me.tsx
+++ b/app/routes/me.tsx
@@ -12,7 +12,7 @@ import {H2, H6} from '../components/typography'
 import {Grid} from '../components/grid'
 import {Input, Label} from '../components/form-elements'
 import {Button} from '../components/button'
-import {CheckIcon} from '../components/icons/check-icon'
+import {CheckCircledIcon} from '../components/icons/check-circled-icon'
 import {LogoutIcon} from '../components/icons/logout-icon'
 import {TEAM_MAP} from '../utils/onboarding'
 import {EyeIcon} from '../components/icons/eye-icon'
@@ -207,7 +207,7 @@ function YouScreen() {
 
             <div className="relative col-span-full mb-3 bg-gray-100 dark:bg-gray-800 rounded-lg focus-within:outline-none ring-2 focus-within:ring-2 ring-team-current ring-offset-4 ring-offset-team-current ring-offset-team-current lg:col-span-4 lg:mb-0">
               <span className="absolute left-9 top-9 text-team-current">
-                <CheckIcon />
+                <CheckCircledIcon />
               </span>
 
               <div className="block pb-12 pt-20 px-12 text-center">

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -17,7 +17,7 @@ import {Grid} from '../components/grid'
 import {H2, H6, Paragraph} from '../components/typography'
 import {Input, InputError, Label} from '../components/form-elements'
 import {Button} from '../components/button'
-import {CheckIcon} from '../components/icons/check-icon'
+import {CheckCircledIcon} from '../components/icons/check-circled-icon'
 import {images} from '../images'
 import {TEAM_MAP} from '../utils/onboarding'
 
@@ -181,7 +181,7 @@ function TeamOption({team: value, error, selected}: TeamOptionProps) {
     >
       {selected ? (
         <span className="absolute left-9 top-9 text-team-current">
-          <CheckIcon />
+          <CheckCircledIcon />
         </span>
       ) : null}
 


### PR DESCRIPTION
Improved the copy-button:

- added copy functionality
- added a "copy confirmation" state
- moved the button on the featured section inside the photo (match the gallery cards)
- removed the copy button from all other feature sections

**TODO:**
- set article urls to be copied (blocked by #53 / decision making)

**PREVIEW:**

https://user-images.githubusercontent.com/1196524/125971669-1256f429-518e-4d6c-a41c-874a18d0c8f8.mp4

