### PR TITLE
fix: limit height of hero for ultra-high screens

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -85,7 +85,7 @@ module.exports = {
         '10vw': '10vw', // page margin
       },
       height: {
-        hero: 'calc(100vh - 10rem)', // screen - navbar height (lg: only)
+        hero: 'min(60rem, calc(100vh - 10rem))', // screen - navbar height (lg: only)
       },
       maxHeight: {
         '50vh': '50vh', // max height for medium size hero images


### PR DESCRIPTION
fixes #64 

Maybe we should also limit the max-width of the navbar to stay closer to the content width? A bit wider as content, but not as wide as shown in #64?