### PR TITLE
feat: render team-charts horizontally and fixed at top/bottom of article

### DIFF
--- a/app/components/team-stats.tsx
+++ b/app/components/team-stats.tsx
@@ -17,40 +17,60 @@ type ReadRanking = {
   percent: number
 }
 
-function Stat({totalReads, team, percent}: ReadRanking) {
+function Stat({
+  totalReads,
+  team,
+  percent,
+  direction,
+}: ReadRanking & {direction: 'up' | 'down'}) {
   const info = useOptionalUserInfo()
   const [currentTeam] = useTeam()
   const avatar = info ? info.avatar : alexProfiles[team]
   const isUsersTeam = team === currentTeam
 
   return (
-    <motion.button
+    <motion.div
+      tabIndex={0}
       initial="initial"
       whileHover="hover"
       whileFocus="hover"
-      className="relative focus:outline-none origin-right"
+      className="relative flex items-center justify-center focus:outline-none origin-right"
       variants={{
-        initial: {height: 22},
-        hover: {height: 38},
+        initial: {width: 22},
       }}
-      transition={{duration: 0.2}}
     >
       <motion.div
         variants={{
-          initial: {width: 8 + 24 * percent, height: 16, padding: 0},
-          hover: {width: 72, height: 36, padding: '0 .5rem'},
+          initial: {
+            height: 12 + 24 * percent,
+            width: 16,
+            y: direction === 'up' ? '-100%' : 0,
+          },
+          hover: {height: 48, width: 24},
         }}
         className={clsx(
-          'z-10 flex items-center justify-end bg-black rounded-l-md origin-right',
+          'relative flex justify-center',
+          {
+            'rounded-t-md': direction === 'up',
+            'rounded-b-md': direction === 'down',
+          },
           barColors[team],
         )}
       >
         <motion.span
           variants={{
-            initial: {opacity: 0, scale: 0.5},
-            hover: {opacity: 1, scale: 1},
+            initial: {opacity: 0, scale: 1, y: 0, fontSize: 0},
+            hover: {
+              opacity: 1,
+              scale: 1,
+              y: direction === 'up' ? '-100%' : '100%',
+              fontSize: '18px',
+            },
           }}
-          className="text-gray-900 text-lg font-medium"
+          className={clsx('text-primary absolute text-lg font-medium', {
+            'bottom-0': direction === 'down',
+            'top-0': direction === 'up',
+          })}
         >
           {new Intl.NumberFormat().format(totalReads)}
         </motion.span>
@@ -58,22 +78,22 @@ function Stat({totalReads, team, percent}: ReadRanking) {
 
       {isUsersTeam ? (
         <motion.div
-          className="absolute top-1/2 hidden bg-team-current rounded-md lg:block"
+          className="absolute left-1/2 top-0 border-team-current rounded-md"
           variants={{
             initial: {
               width: 22,
               height: 22,
-              y: '-50%',
-              x: 40,
-              padding: 2,
+              x: '-50%',
+              y: direction === 'up' ? 4 : -26,
+              borderWidth: 2,
               borderRadius: 4,
             },
             hover: {
               width: 36,
               height: 36,
-              y: '-50%',
-              x: 84,
-              padding: 3,
+              x: '-50%',
+              y: direction === 'up' ? 6 : -42,
+              borderWidth: 3,
               borderRadius: 8,
             },
           }}
@@ -83,28 +103,47 @@ function Stat({totalReads, team, percent}: ReadRanking) {
               initial: {borderWidth: 2, borderRadius: 4 - 2},
               hover: {borderWidth: 4, borderRadius: 8 - 3},
             }}
-            className="w-full h-full border-2 dark:border-gray-900 border-white object-cover"
+            className="w-full h-full dark:border-gray-900 border-white object-cover"
             src={avatar.src}
             alt={avatar.alt}
           />
         </motion.div>
       ) : null}
-    </motion.button>
+    </motion.div>
   )
 }
 
-function TeamStats({rankings}: {rankings: Array<ReadRanking>}) {
+function TeamStats({
+  rankings,
+  direction = 'up',
+}: {
+  rankings: Array<ReadRanking>
+  direction: 'up' | 'down'
+}) {
   // sort rankings to be [second, first, last], just like contest stages, but
   // reversed due to orientation. Sorting on ranking 1, 2, 3, results in stair like
   // structures, which doesn't look pretty
   const resorted = [rankings[2], rankings[0], rankings[1]] as Array<ReadRanking>
 
   return (
-    <div className="fixed z-40 left-1/2 top-1/2 mx-auto w-full max-w-8xl transform -translate-x-1/2 -translate-y-1/2">
-      <ul className="absolute right-1 top-0 py-4 border-r border-team-current transform -translate-y-1/2 md:right-4">
+    <div
+      className={clsx('inline-flex flex-col justify-end', {
+        'justify-end': direction === 'down',
+        'justify-start': direction === 'up',
+      })}
+    >
+      <ul
+        className={clsx(
+          'relative flex px-4 h-0 border-team-current overflow-visible',
+          {
+            'border-t': direction === 'down',
+            'border-b': direction === 'up',
+          },
+        )}
+      >
         {resorted.map(ranking => (
-          <li key={ranking.team} className="flex items-center justify-end">
-            <Stat {...ranking} />
+          <li key={ranking.team} className="h-0 overflow-visible">
+            <Stat direction={direction} {...ranking} />
           </li>
         ))}
       </ul>

--- a/app/components/team-stats.tsx
+++ b/app/components/team-stats.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import {motion} from 'framer-motion'
 import clsx from 'clsx'
 import type {Team} from '@prisma/client'
+import {useOptionalUserInfo, useTeam} from '../utils/providers'
+import {alexProfiles} from '../images'
 
 const barColors: Record<Team, string> = {
   RED: 'bg-team-red',
@@ -16,6 +18,11 @@ type ReadRanking = {
 }
 
 function Stat({totalReads, team, percent}: ReadRanking) {
+  const info = useOptionalUserInfo()
+  const [currentTeam] = useTeam()
+  const avatar = info ? info.avatar : alexProfiles[team]
+  const isUsersTeam = team === currentTeam
+
   return (
     <motion.button
       initial="initial"
@@ -48,6 +55,40 @@ function Stat({totalReads, team, percent}: ReadRanking) {
           {new Intl.NumberFormat().format(totalReads)}
         </motion.span>
       </motion.div>
+
+      {isUsersTeam ? (
+        <motion.div
+          className="absolute top-1/2 hidden bg-team-current rounded-md lg:block"
+          variants={{
+            initial: {
+              width: 22,
+              height: 22,
+              y: '-50%',
+              x: 40,
+              padding: 2,
+              borderRadius: 4,
+            },
+            hover: {
+              width: 36,
+              height: 36,
+              y: '-50%',
+              x: 84,
+              padding: 3,
+              borderRadius: 8,
+            },
+          }}
+        >
+          <motion.img
+            variants={{
+              initial: {borderWidth: 2, borderRadius: 4 - 2},
+              hover: {borderWidth: 4, borderRadius: 8 - 3},
+            }}
+            className="w-full h-full border-2 dark:border-gray-900 border-white object-cover"
+            src={avatar.src}
+            alt={avatar.alt}
+          />
+        </motion.div>
+      ) : null}
     </motion.button>
   )
 }
@@ -59,8 +100,8 @@ function TeamStats({rankings}: {rankings: Array<ReadRanking>}) {
   const resorted = [rankings[2], rankings[0], rankings[1]] as Array<ReadRanking>
 
   return (
-    <div className="fixed z-40 right-2 top-1/2 transform -translate-y-1/2 md:right-8">
-      <ul className="py-4 border-r border-team-current">
+    <div className="fixed z-40 left-1/2 top-1/2 mx-auto w-full max-w-8xl transform -translate-x-1/2 -translate-y-1/2">
+      <ul className="absolute right-1 top-0 py-4 border-r border-team-current transform -translate-y-1/2 md:right-4">
         {resorted.map(ranking => (
           <li key={ranking.team} className="flex items-center justify-end">
             <Stat {...ranking} />

--- a/app/components/team-stats.tsx
+++ b/app/components/team-stats.tsx
@@ -3,7 +3,7 @@ import {motion} from 'framer-motion'
 import clsx from 'clsx'
 import type {Team} from '@prisma/client'
 
-const rankingColors: Record<Team, string> = {
+const barColors: Record<Team, string> = {
   RED: 'bg-team-red',
   YELLOW: 'bg-team-yellow',
   BLUE: 'bg-team-blue',
@@ -30,12 +30,12 @@ function Stat({totalReads, team, percent}: ReadRanking) {
     >
       <motion.div
         variants={{
-          initial: {width: 16 + 12 * percent, height: 16},
-          hover: {width: 72, height: 36},
+          initial: {width: 8 + 24 * percent, height: 16, padding: 0},
+          hover: {width: 72, height: 36, padding: '0 .5rem'},
         }}
         className={clsx(
-          'z-10 flex items-center justify-end px-2 bg-black rounded-l-md origin-right',
-          rankingColors[team],
+          'z-10 flex items-center justify-end bg-black rounded-l-md origin-right',
+          barColors[team],
         )}
       >
         <motion.span

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -170,14 +170,14 @@ function ArticleFooter() {
           </Link>
         </div>
 
-        <div className="flex items-center">
+        <div className="flex">
           <Link
             className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
             to="/"
           >
             Discuss on Twitter
           </Link>
-          <span className="mx-3 text-xs">•</span>
+          <span className="self-center mx-3 text-xs">•</span>
           <Link
             className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
             to="/"
@@ -255,12 +255,10 @@ function MdxScreen() {
   return (
     <>
       <Grid className="mb-10 mt-24 lg:mb-24">
-        <BackLink
-          to="/blog"
-          className="lg-col-span-8 col-span-full lg:col-start-3"
-        >
-          Back to overview
-        </BackLink>
+        <div className="flex col-span-full justify-between lg:col-span-8 lg:col-start-3">
+          <BackLink to="/blog">Back to overview</BackLink>
+          <TeamStats rankings={data.readRankings} direction="down" />
+        </div>
       </Grid>
 
       <Grid as="header" className="mb-12">
@@ -281,9 +279,7 @@ function MdxScreen() {
       </Grid>
 
       <main ref={readMarker}>
-        <TeamStats rankings={data.readRankings} />
-
-        <Grid className="mb-16">
+        <Grid className="mb-24">
           <div className="col-span-full lg:col-start-3">
             <div className="flex flex-wrap">
               {frontmatter.translations?.length ? (
@@ -337,6 +333,12 @@ function MdxScreen() {
           <Component components={MdxComponentMap} />
         </Grid>
       </main>
+
+      <Grid className="mb-24">
+        <div className="flex col-span-full justify-end lg:col-span-8 lg:col-start-3">
+          <TeamStats rankings={data.readRankings} direction="up" />
+        </div>
+      </Grid>
 
       <div className="mb-64">
         <ArticleFooter />


### PR DESCRIPTION
- increased the size difference between bars
- rendered them horizontally
- fixed to top and bottom of the article, instead of sticky on screen
- added user avatar in case they're logged in


https://user-images.githubusercontent.com/1196524/126388598-facfe787-e064-44df-a2ed-6bd24023c1d5.mp4

