### PR TITLE
feat: add join button to hero on discord page

### DIFF
--- a/app/routes/discord.tsx
+++ b/app/routes/discord.tsx
@@ -138,6 +138,11 @@ export default function Discord() {
         imageAlt={images.helmet.alt}
         arrowUrl="#reasons-to-join"
         arrowLabel="Is this something for me?"
+        action={
+          <ButtonLink variant="primary" to={authorizeURL}>
+            Join Discord
+          </ButtonLink>
+        }
       />
 
       <Grid className="mb-24 lg:mb-64">


### PR DESCRIPTION
Not sure what happened. It should have been there, but according to git log, it never existed.

Anyways, (re)added the join button to the discord hero:

![image](https://user-images.githubusercontent.com/1196524/126504345-c454038b-f5b4-40b7-93de-64bdee263d32.png)
 