### PR TITLE
feat: implement call page

### DIFF
--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -91,7 +91,7 @@ export default function CallHomeScreen() {
       />
 
       {/*
-        IDEA: when there will be manyu episodes, we could split this by year, and
+        IDEA: when there will be many episodes, we could split this by year, and
         display it with tabs like on the podcast page. [2023, 2022, 2021]
       */}
       <Grid className="mb-24 lg:mb-64">

--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -126,84 +126,86 @@ export default function CallHomeScreen() {
         </div>
 
         <div className="col-span-full">
-          {sortedEpisodes.map((episode, idx, {length}) => {
-            const number =
-              sortOrder === 'asc' ? idx + 1 : Math.abs(length - idx)
+          <CallKentEpisodesProvider value={data.episodes}>
+            {sortedEpisodes.map((episode, idx, {length}) => {
+              const number =
+                sortOrder === 'asc' ? idx + 1 : Math.abs(length - idx)
 
-            return (
-              <div
-                className="border-b border-gray-200 dark:border-gray-600"
-                key={episode.slug}
-              >
-                <Link
-                  data-episode={episode.slug}
+              return (
+                <div
+                  className="border-b border-gray-200 dark:border-gray-600"
                   key={episode.slug}
-                  to={activeSlug === episode.slug ? './' : `./${episode.slug}`}
                 >
-                  <Grid nested className="group relative py-10 lg:py-5">
-                    <div className="bg-secondary absolute -inset-px group-hover:block hidden -mx-6 rounded-lg" />
-                    <div className="relative flex-none col-span-1">
-                      <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transform scale-0 group-hover:scale-100 transition">
-                        <div className="flex-none p-4 text-gray-800 bg-white rounded-full">
-                          <TriangleIcon size={12} />
+                  <Link
+                    data-episode={episode.slug}
+                    key={episode.slug}
+                    to={
+                      activeSlug === episode.slug ? './' : `./${episode.slug}`
+                    }
+                  >
+                    <Grid nested className="group relative py-10 lg:py-5">
+                      <div className="bg-secondary absolute -inset-px group-hover:block hidden -mx-6 rounded-lg" />
+                      <div className="relative flex-none col-span-1">
+                        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transform scale-0 group-hover:scale-100 transition">
+                          <div className="flex-none p-4 text-gray-800 bg-white rounded-full">
+                            <TriangleIcon size={12} />
+                          </div>
+                        </div>
+                        <img
+                          className="w-full rounded-lg object-cover"
+                          src={episode.imageUrl}
+                          alt={episode.title}
+                        />
+                      </div>
+                      <div className="text-primary relative flex flex-col col-span-3 md:col-span-7 lg:flex-row lg:col-span-11 lg:items-center lg:justify-between">
+                        <div className="mb-3 text-xl font-medium lg:mb-0">
+                          {/* TODO: make it three digits? How many calls do we expect? */}
+                          <span className="inline-block w-10 lg:text-lg">
+                            {`${number.toString().padStart(2, '0')}.`}
+                          </span>
+
+                          {episode.title}
+                        </div>
+                        <div className="text-gray-400 text-lg font-medium">
+                          {formatTime(episode.duration)}
                         </div>
                       </div>
-                      <img
-                        className="w-full rounded-lg object-cover"
-                        src={episode.imageUrl}
-                        alt={episode.title}
-                      />
-                    </div>
-                    <div className="text-primary relative flex flex-col col-span-3 md:col-span-7 lg:flex-row lg:col-span-11 lg:items-center lg:justify-between">
-                      <div className="mb-3 text-xl font-medium lg:mb-0">
-                        {/* TODO: make it three digits? How many calls do we expect? */}
-                        <span className="inline-block w-10 lg:text-lg">
-                          {`${number.toString().padStart(2, '0')}.`}
-                        </span>
+                    </Grid>
+                  </Link>
 
-                        {episode.title}
-                      </div>
-                      <div className="text-gray-400 text-lg font-medium">
-                        {formatTime(episode.duration)}
-                      </div>
-                    </div>
-                  </Grid>
-                </Link>
-
-                <Grid nested>
-                  <AnimatePresence>
-                    {activeSlug === episode.slug ? (
-                      <motion.div
-                        variants={{
-                          collapsed: {
-                            height: 0,
-                            marginTop: 0,
-                            marginBottom: 0,
-                            opacity: 0,
-                          },
-                          expanded: {
-                            height: 'auto',
-                            marginTop: '1rem',
-                            marginBottom: '3rem',
-                            opacity: 1,
-                          },
-                        }}
-                        initial="collapsed"
-                        animate="expanded"
-                        exit="collapsed"
-                        transition={{duration: 0.15}}
-                        className="relative col-span-full"
-                      >
-                        <CallKentEpisodesProvider value={data.episodes}>
+                  <Grid nested>
+                    <AnimatePresence>
+                      {activeSlug === episode.slug ? (
+                        <motion.div
+                          variants={{
+                            collapsed: {
+                              height: 0,
+                              marginTop: 0,
+                              marginBottom: 0,
+                              opacity: 0,
+                            },
+                            expanded: {
+                              height: 'auto',
+                              marginTop: '1rem',
+                              marginBottom: '3rem',
+                              opacity: 1,
+                            },
+                          }}
+                          initial="collapsed"
+                          animate="expanded"
+                          exit="collapsed"
+                          transition={{duration: 0.15}}
+                          className="relative col-span-full"
+                        >
                           <Outlet />
-                        </CallKentEpisodesProvider>
-                      </motion.div>
-                    ) : null}
-                  </AnimatePresence>
-                </Grid>
-              </div>
-            )
-          })}
+                        </motion.div>
+                      ) : null}
+                    </AnimatePresence>
+                  </Grid>
+                </div>
+              )
+            })}
+          </CallKentEpisodesProvider>
         </div>
       </Grid>
 

--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -20,6 +20,7 @@ import {HeaderSection} from '../components/sections/header-section'
 import {TriangleIcon} from '../components/icons/triangle-icon'
 import {formatTime} from '../utils/misc'
 import {AnimatePresence, motion} from 'framer-motion'
+import {useRef} from 'react'
 
 type LoaderData = {
   episodes: Await<ReturnType<typeof getEpisodes>>
@@ -54,19 +55,19 @@ export default function CallHomeScreen() {
   const avatar = alexProfiles[team]
 
   const activeSlug = pathname.replace('/call/', '')
+  const initialActiveSlugRef = useRef(activeSlug)
 
   const sortedEpisodes =
     sortOrder === 'desc' ? data.episodes : [...data.episodes].reverse()
 
-  // An effect to scroll to the episode's position when opening a direct link
+  // An effect to scroll to the episode's position when opening a direct link,
+  // use a ref so that it doesn't hijack scroll when the user is browsing episodes
   React.useEffect(() => {
-    if (activeSlug) {
-      document.querySelector(`[data-episode="${activeSlug}"]`)?.scrollIntoView()
+    const episode = initialActiveSlugRef.current
+    if (episode) {
+      document.querySelector(`[data-episode="${episode}"]`)?.scrollIntoView()
     }
-    // we really only want to run this on mount. Otherwise it will hijack the
-    // users scroll while they browse the episodes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [initialActiveSlugRef])
 
   return (
     <>

--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -21,6 +21,7 @@ import {TriangleIcon} from '../components/icons/triangle-icon'
 import {formatTime} from '../utils/misc'
 import {AnimatePresence, motion} from 'framer-motion'
 import {useRef} from 'react'
+import clsx from 'clsx'
 
 type LoaderData = {
   episodes: Await<ReturnType<typeof getEpisodes>>
@@ -68,6 +69,9 @@ export default function CallHomeScreen() {
       document.querySelector(`[data-episode="${episode}"]`)?.scrollIntoView()
     }
   }, [initialActiveSlugRef])
+
+  // used to automatically prefix numbers with the correct amount of zeros
+  const numberLength = sortedEpisodes.length.toString().length
 
   return (
     <>
@@ -159,9 +163,17 @@ export default function CallHomeScreen() {
                       </div>
                       <div className="text-primary relative flex flex-col col-span-3 md:col-span-7 lg:flex-row lg:col-span-11 lg:items-center lg:justify-between">
                         <div className="mb-3 text-xl font-medium lg:mb-0">
-                          {/* TODO: make it three digits? How many calls do we expect? */}
-                          <span className="inline-block w-10 lg:text-lg">
-                            {`${number.toString().padStart(2, '0')}.`}
+                          {/* For most optimal display, this will needs adjustment once you'll hit 5 digits */}
+                          <span
+                            className={clsx('inline-block lg:text-lg', {
+                              'w-10': numberLength <= 3,
+                              'w-14': numberLength === 4,
+                              'w-auto pr-4': numberLength > 4,
+                            })}
+                          >
+                            {`${number
+                              .toString()
+                              .padStart(numberLength, '0')}.`}
                           </span>
 
                           {episode.title}

--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -1,15 +1,29 @@
 import * as React from 'react'
 import {json, Link, useRouteData} from 'remix'
 import type {LoaderFunction} from 'remix'
-import {Outlet} from 'react-router-dom'
+import {Outlet, useLocation} from 'react-router-dom'
 import type {Await} from 'types'
 import {getEpisodes} from '../utils/call-kent.server'
-import {CallKentEpisodesProvider} from '../utils/providers'
+import {CallKentEpisodesProvider, useTeam} from '../utils/providers'
 import {getUser} from '../utils/session.server'
 import {refreshEpisodes} from '../utils/transistor.server'
+import {HeroSection} from '../components/sections/hero-section'
+import {alexProfiles} from '../images'
+import {ButtonLink} from '../components/button'
+import {Grid} from '../components/grid'
+import {getBlogRecommendations} from '../utils/blog.server'
+import {BlogSection} from '../components/sections/blog-section'
+import {H6} from '../components/typography'
+import {ChevronUpIcon} from '../components/icons/chevron-up-icon'
+import {ChevronDownIcon} from '../components/icons/chevron-down-icon'
+import {HeaderSection} from '../components/sections/header-section'
+import {TriangleIcon} from '../components/icons/triangle-icon'
+import {formatTime} from '../utils/misc'
+import {AnimatePresence, motion} from 'framer-motion'
 
 type LoaderData = {
   episodes: Await<ReturnType<typeof getEpisodes>>
+  blogRecommendations: Await<ReturnType<typeof getBlogRecommendations>>
 }
 
 export const loader: LoaderFunction = async ({request}) => {
@@ -20,30 +34,183 @@ export const loader: LoaderFunction = async ({request}) => {
     }
   }
 
-  const data: LoaderData = {episodes: await getEpisodes()}
-  return json(data)
+  const [blogRecommendations, episodes] = await Promise.all([
+    getBlogRecommendations({limit: 3}),
+    getEpisodes(),
+  ])
+
+  return json({
+    blogRecommendations,
+    episodes,
+  })
 }
 
 export default function CallHomeScreen() {
+  const {pathname} = useLocation()
+  const [sortOrder, setSortOrder] = React.useState<'asc' | 'desc'>('asc')
+
   const data = useRouteData<LoaderData>()
+  const [team] = useTeam()
+  const avatar = alexProfiles[team]
+
+  const activeSlug = pathname.replace('/call/', '')
+
+  const sortedEpisodes =
+    sortOrder === 'desc' ? data.episodes : [...data.episodes].reverse()
+
+  // An effect to scroll to the episode's position when opening a direct link
+  React.useEffect(() => {
+    if (activeSlug) {
+      document.querySelector(`[data-episode="${activeSlug}"]`)?.scrollIntoView()
+    }
+    // we really only want to run this on mount. Otherwise it will hijack the
+    // users scroll while they browse the episodes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
-    <div>
-      <h2>Welcome to the Call Kent Podcast</h2>
-      <Link to="./record">Record your own call</Link>
-      <div className="flex">
-        <div className="w-52 overscroll-auto">
-          <ul>
-            {data.episodes.map(episode => (
-              <li key={episode.slug}>
-                <Link to={`./${episode.slug}`}>{episode.title}</Link>
-              </li>
-            ))}
-          </ul>
+    <>
+      <HeroSection
+        title="Calls with Kent C. Dodds."
+        subtitle="You call, I'll answer."
+        imageUrl={avatar.src}
+        imageAlt={avatar.alt}
+        arrowUrl="#episodes"
+        arrowLabel="Wanna see my call logs?"
+        action={
+          <ButtonLink variant="primary" to="./record">
+            Record your call
+          </ButtonLink>
+        }
+      />
+
+      <HeaderSection
+        className="mb-16"
+        title="This thing is a bit new."
+        subTitle="But here is what we got."
+      />
+
+      {/*
+        IDEA: when there will be manyu episodes, we could split this by year, and
+        display it with tabs like on the podcast page. [2023, 2022, 2021]
+      */}
+      <Grid className="mb-24 lg:mb-64">
+        <div className="flex flex-col col-span-full mb-6 lg:flex-row lg:justify-between lg:mb-12">
+          <H6
+            id="episodes"
+            as="h2"
+            className="flex flex-col col-span-full mb-10 lg:flex-row lg:mb-0"
+          >
+            <span>Calls with Kent C. Dodds</span>
+            &nbsp;
+            <span>{` — ${data.episodes.length} episodes`}</span>
+          </H6>
+
+          <button
+            className="text-primary inline-flex items-center text-lg font-medium"
+            onClick={() => setSortOrder(o => (o === 'asc' ? 'desc' : 'asc'))}
+          >
+            {sortOrder === 'asc' ? (
+              <>
+                Showing oldest first
+                <ChevronUpIcon className="ml-2 text-gray-400" />
+              </>
+            ) : (
+              <>
+                Showing newest first
+                <ChevronDownIcon className="ml-2 text-gray-400" />
+              </>
+            )}
+          </button>
         </div>
-        <CallKentEpisodesProvider value={data.episodes}>
-          <Outlet />
-        </CallKentEpisodesProvider>
-      </div>
-    </div>
+
+        <div className="col-span-full">
+          {sortedEpisodes.map((episode, idx, {length}) => {
+            const number =
+              sortOrder === 'asc' ? idx + 1 : Math.abs(length - idx)
+
+            return (
+              <div
+                className="border-b border-gray-200 dark:border-gray-600"
+                key={episode.slug}
+              >
+                <Link
+                  data-episode={episode.slug}
+                  key={episode.slug}
+                  to={activeSlug === episode.slug ? './' : `./${episode.slug}`}
+                >
+                  <Grid nested className="group relative py-10 lg:py-5">
+                    <div className="bg-secondary absolute -inset-px group-hover:block hidden -mx-6 rounded-lg" />
+                    <div className="relative flex-none col-span-1">
+                      <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transform scale-0 group-hover:scale-100 transition">
+                        <div className="flex-none p-4 text-gray-800 bg-white rounded-full">
+                          <TriangleIcon size={12} />
+                        </div>
+                      </div>
+                      <img
+                        className="w-full rounded-lg object-cover"
+                        src={episode.imageUrl}
+                        alt={episode.title}
+                      />
+                    </div>
+                    <div className="text-primary relative flex flex-col col-span-3 md:col-span-7 lg:flex-row lg:col-span-11 lg:items-center lg:justify-between">
+                      <div className="mb-3 text-xl font-medium lg:mb-0">
+                        {/* TODO: make it three digits? How many calls do we expect? */}
+                        <span className="inline-block w-10 lg:text-lg">
+                          {`${number.toString().padStart(2, '0')}.`}
+                        </span>
+
+                        {episode.title}
+                      </div>
+                      <div className="text-gray-400 text-lg font-medium">
+                        {formatTime(episode.duration)}
+                      </div>
+                    </div>
+                  </Grid>
+                </Link>
+
+                <Grid nested>
+                  <AnimatePresence>
+                    {activeSlug === episode.slug ? (
+                      <motion.div
+                        variants={{
+                          collapsed: {
+                            height: 0,
+                            marginTop: 0,
+                            marginBottom: 0,
+                            opacity: 0,
+                          },
+                          expanded: {
+                            height: 'auto',
+                            marginTop: '1rem',
+                            marginBottom: '3rem',
+                            opacity: 1,
+                          },
+                        }}
+                        initial="collapsed"
+                        animate="expanded"
+                        exit="collapsed"
+                        transition={{duration: 0.15}}
+                        className="relative col-span-full"
+                      >
+                        <CallKentEpisodesProvider value={data.episodes}>
+                          <Outlet />
+                        </CallKentEpisodesProvider>
+                      </motion.div>
+                    ) : null}
+                  </AnimatePresence>
+                </Grid>
+              </div>
+            )
+          })}
+        </div>
+      </Grid>
+
+      <BlogSection
+        articles={data.blogRecommendations}
+        title="Looking for more content?"
+        description="Have a look at these articles."
+      />
+    </>
   )
 }

--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -154,11 +154,12 @@ export default function CallHomeScreen() {
                     to={
                       activeSlug === episode.slug ? './' : `./${episode.slug}`
                     }
+                    className="group focus:outline-none"
                   >
-                    <Grid nested className="group relative py-10 lg:py-5">
-                      <div className="bg-secondary absolute -inset-px group-hover:block hidden -mx-6 rounded-lg" />
+                    <Grid nested className="relative py-10 lg:py-5">
+                      <div className="bg-secondary absolute -inset-px group-hover:block group-focus:block hidden -mx-6 rounded-lg" />
                       <div className="relative flex-none col-span-1">
-                        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transform scale-0 group-hover:scale-100 transition">
+                        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-focus:opacity-100 group-hover:opacity-100 transform scale-0 group-focus:scale-100 group-hover:scale-100 transition">
                           <div className="flex-none p-4 text-gray-800 bg-white rounded-full">
                             <TriangleIcon size={12} />
                           </div>

--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -13,7 +13,7 @@ import {ButtonLink} from '../components/button'
 import {Grid} from '../components/grid'
 import {getBlogRecommendations} from '../utils/blog.server'
 import {BlogSection} from '../components/sections/blog-section'
-import {H6} from '../components/typography'
+import {H6, Paragraph} from '../components/typography'
 import {ChevronUpIcon} from '../components/icons/chevron-up-icon'
 import {ChevronDownIcon} from '../components/icons/chevron-down-icon'
 import {HeaderSection} from '../components/sections/header-section'
@@ -134,6 +134,14 @@ export default function CallHomeScreen() {
             {sortedEpisodes.map((episode, idx, {length}) => {
               const number =
                 sortOrder === 'asc' ? idx + 1 : Math.abs(length - idx)
+              const keywords = Array.from(
+                new Set(
+                  episode.keywords
+                    .split(/[,;\s]/g) // split into words
+                    .map(x => x.trim()) // trim white spaces
+                    .filter(Boolean), // remove empties
+                ), // omit duplicates
+              ).slice(0, 3) // keep first 3 only
 
               return (
                 <div
@@ -209,6 +217,15 @@ export default function CallHomeScreen() {
                           transition={{duration: 0.15}}
                           className="relative col-span-full"
                         >
+                          <H6 as="div">Keywords</H6>
+                          <Paragraph className="flex mb-8">
+                            {keywords.join(', ')}
+                          </Paragraph>
+
+                          <H6 as="div">Description</H6>
+                          <Paragraph className="mb-8">
+                            {episode.description}
+                          </Paragraph>
                           <Outlet />
                         </motion.div>
                       ) : null}

--- a/app/routes/call/$slug.tsx
+++ b/app/routes/call/$slug.tsx
@@ -3,6 +3,7 @@ import {useParams} from 'react-router-dom'
 import type {KCDLoader} from 'types'
 import {useCallKentEpisodes} from '../../utils/providers'
 import {getEpisodes} from '../../utils/call-kent.server'
+import {useTheme} from '../../utils/theme-provider'
 
 export const loader: KCDLoader<{
   slug: string
@@ -24,12 +25,17 @@ export default function Screen() {
   const params = useParams() as {slug: string}
   const episodes = useCallKentEpisodes()
   const episode = episodes.find(e => e.slug === params.slug)
+  const [theme] = useTheme()
+
   if (!episode) {
     return <div>Oh no... No episode found with this slug: {params.slug}</div>
   }
+
   return (
-    <div>
-      <pre>{JSON.stringify(episode, null, 2)}</pre>
-    </div>
+    <div
+      dangerouslySetInnerHTML={{
+        __html: theme === 'dark' ? episode.embedHtmlDark : episode.embedHtml,
+      }}
+    />
   )
 }

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -38,7 +38,7 @@ export const loader: LoaderFunction = async ({request}) => {
     }
   }
 
-  const blogRecommendations = (await getBlogRecommendations()).slice(0, 3)
+  const blogRecommendations = await getBlogRecommendations({limit: 3})
   const data: LoaderData = {
     // we show the seasons in reverse order
     seasons: (await getSeasonListItems()).reverse(),

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -21,7 +21,7 @@ type LoaderData = {
 }
 
 export const loader: LoaderFunction = async () => {
-  const blogRecommendations = (await getBlogRecommendations()).slice(0, 3)
+  const blogRecommendations = await getBlogRecommendations({limit: 3})
 
   const data: LoaderData = {blogRecommendations}
   return json(data)

--- a/app/utils/blog.server.ts
+++ b/app/utils/blog.server.ts
@@ -4,10 +4,14 @@ import {getBlogMdxListItems} from './mdx'
 import {prisma} from './prisma.server'
 import {teams} from './misc'
 
-async function getBlogRecommendations() {
+async function getBlogRecommendations({limit}: {limit?: number} = {}) {
   const posts = await getBlogMdxListItems()
 
-  return posts
+  if (typeof limit !== 'undefined') {
+    return posts
+  }
+
+  return posts.slice(0, limit)
 }
 
 async function getBlogReadRankings(slug: string) {

--- a/mocks/transistor.ts
+++ b/mocks/transistor.ts
@@ -104,12 +104,12 @@ const transistorHandlers: Array<
             keywords: faker.lorem.words().split(' ').join(','),
             status: 'published',
             image_url: faker.internet.avatar(),
-            media_url: 'https://media.transistor.fm/eac55340/b307611b.mp3',
-            share_url: 'https://share.transistor.fm/s/eac55340',
+            media_url: 'https://media.transistor.fm/1493e91f/10e5e65b.mp3',
+            share_url: 'https://share.transistor.fm/s/1493e91f',
             embed_html:
-              '<iframe width="100%" height="180" frameborder="no" scrolling="no" seamless src="https://share.transistor.fm/e/51c83e8d"></iframe>',
+              '<iframe src="https://share.transistor.fm/e/1493e91f" width="100%" height="180" frameborder="0" scrolling="no" seamless style="width:100%; height:180px;"></iframe>',
             embed_html_dark:
-              '<iframe width="100%" height="180" frameborder="no" scrolling="no" seamless src="https://share.transistor.fm/e/51c83e8d/dark"></iframe>',
+              '<iframe src="https://share.transistor.fm/e/1493e91f/dark" width="100%" height="180" frameborder="0" scrolling="no" seamless style="width:100%; height:180px;"></iframe>',
             published_at: faker.datatype
               .datetime({
                 max: Date.now() - 1000 * 60 * 60 * 24,


### PR DESCRIPTION
Added color and content to the `/call` page. The design is inspired by `/chats` (podcast), but instead of opening every call in a details page, they expand and show the player inline.

**TODOS**

- Alex is rendered, but in low quality. We need higher resolution images

**IDEAS**

_copied from Discord:_

- Add search (like on blog page)
- Add keyword filter (like on blog page)
- Display summary on each row, and the description in expanded view?
- Display the keywords on each row as well?