### PR TITLE
feat: render content/pages using prose classes

### DIFF
--- a/app/routes/$slug.tsx
+++ b/app/routes/$slug.tsx
@@ -9,6 +9,9 @@ import {
 } from '../utils/mdx'
 import {FourOhFour} from '../components/errors'
 import {getUser} from '../utils/session.server'
+import {Grid} from '../components/grid'
+import {BackLink} from '../components/arrow-button'
+import {H2, H6} from '../components/typography'
 
 export const loader: KCDLoader<{slug: string}> = async ({params, request}) => {
   const pageMeta = {
@@ -42,13 +45,33 @@ function MdxScreen({mdxPage}: {mdxPage: MdxPage}) {
 
   return (
     <>
-      <header>
-        <h2>{frontmatter.title}</h2>
-        <p>{frontmatter.description}</p>
-      </header>
-      <main>
+      <Grid className="mb-10 mt-24 lg:mb-24">
+        <div className="flex col-span-full justify-between lg:col-span-8 lg:col-start-3">
+          <BackLink to="/">Back to home</BackLink>
+        </div>
+      </Grid>
+
+      <Grid className="mb-12">
+        <div className="col-span-full lg:col-span-8 lg:col-start-3">
+          <H2>{frontmatter.title}</H2>
+          {frontmatter.description ? (
+            <H6 as="p" variant="secondary" className="mt-2 lowercase">
+              {frontmatter.description}
+            </H6>
+          ) : null}
+        </div>
+        {frontmatter.bannerUrl ? (
+          <img
+            className="col-span-full mt-10 mx-auto rounded-lg lg:col-span-10 lg:col-start-2"
+            src={frontmatter.bannerUrl}
+            alt={frontmatter.bannerAlt}
+          />
+        ) : null}
+      </Grid>
+
+      <Grid className="prose prose-light dark:prose-dark">
         <Component />
-      </main>
+      </Grid>
     </>
   )
 }

--- a/content/pages/about.mdx
+++ b/content/pages/about.mdx
@@ -1,6 +1,0 @@
----
-title: About Kent C. Dodds
-description: This page will tell you all about Kent C. Dodds
----
-
-Heyo!

--- a/content/pages/appearances.mdx
+++ b/content/pages/appearances.mdx
@@ -1,9 +1,7 @@
 ---
-title: Appearances | Kent C. Dodds
+title: Appearances
 description: Podcasts, interviews, and blogposts where you can find me featured
 ---
-
-# Appearances
 
 ## Podcasts
 

--- a/content/pages/clubs.mdx
+++ b/content/pages/clubs.mdx
@@ -3,8 +3,6 @@ title: KCD Learning Clubs
 description: Join a KCD Learning Club and learn software together.
 ---
 
-# KCD Learning Clubs
-
 ![I freaking love learning](https://res.cloudinary.com/kentcdodds-com/image/upload/v1616104820/kentcdodds.com/learning_v19ylq.jpg)
 
 A **KCD Learning Club** is a group of up to 10 people who are going through

--- a/content/pages/links.mdx
+++ b/content/pages/links.mdx
@@ -1,11 +1,7 @@
 ---
-title: Links | Kent C. Dodds
-description: A random collection of relevant links about Kent C. Dodds
+title: Links
+description: Links to some things about me...
 ---
-
-# Links
-
-Links to some things about me...
 
 - [Home](http://kentcdodds.com) - This website :)
 - [Links](http://kentcdodds.com/links) - This page

--- a/content/pages/transparency.mdx
+++ b/content/pages/transparency.mdx
@@ -1,13 +1,9 @@
 ---
 title: Transparency | Kent C. Dodds
-description: How Kent makes and uses money
----
-
-# Transparency
-
-I am self employed. This page describes some things to give you an idea of where
+description: I am self employed. This page describes some things to give you an idea of where
 my money comes from (how you can help me keep my business sustainable) and where
 my money goes (what you're supporting when you support me).
+---
 
 ## Mission
 


### PR DESCRIPTION
I've applied the same header/image/content logic to the content pages, as we do for blog articles. This results in pretty rendering for:

- /appearances
- /clubs
- /conduct
- /info
- /links
- /transparency

I think the pages would benefit immensely if we'd added some banner images to them.