### PR TITLE
fix: use native anchors for external links

### DIFF
--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -51,6 +51,14 @@ const ButtonLink = React.forwardRef<
   HTMLAnchorElement,
   ButtonProps & Pick<LinkProps, 'to' | 'className'>
 >(function ButtonLink({children, variant = 'primary', className, to}, ref) {
+  if (typeof to === 'string' && (to.startsWith('http') || to.startsWith('#'))) {
+    return (
+      <a ref={ref} href={to} className={getClassName({variant, className})}>
+        {children}
+      </a>
+    )
+  }
+
   return (
     <Link ref={ref} to={to} className={getClassName({variant, className})}>
       {children}


### PR DESCRIPTION
Add support for external links to the `ButtonLink`, which is used by the `CourseCard`. Without this, the destination url becomes `https://kent.dev/https://testingjavascript.com`.