### PR TITLE
fix: various visual improvements across the whole site

### DIFF
--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -8,25 +8,45 @@ interface ButtonProps {
   children: React.ReactNode | React.ReactNode[]
 }
 
-function getClassName({
+function getClassName({className}: {className?: string}) {
+  return clsx(
+    'group relative inline-flex text-lg font-medium opacity-100 disabled:opacity-50 transition',
+    className,
+  )
+}
+
+function ButtonInner({
+  children,
   variant,
   size,
-  className,
-}: {
-  variant: ButtonProps['variant']
-  size?: ButtonProps['size']
-  className?: string
-}) {
-  return clsx(
-    'focus-ring inline-flex items-center justify-center whitespace-nowrap text-lg font-medium rounded-full opacity-100 disabled:opacity-50 transition',
-    {
-      'border-2 dark:border-gray-600 border-gray-200 text-primary bg-primary':
-        variant === 'secondary',
-      'bg-inverse text-inverse': variant === 'primary',
-      'px-11 py-6 space-x-5': size !== 'medium',
-      'px-8 py-4 space-x-3': size === 'medium',
-    },
-    className,
+}: Pick<ButtonProps, 'children' | 'variant' | 'size'>) {
+  return (
+    <>
+      <div
+        className={clsx(
+          'focus-ring absolute inset-0 rounded-full opacity-100 disabled:opacity-50 transform transition',
+          {
+            'border-2 border-secondary bg-primary group-hover:border-transparent':
+              variant === 'secondary',
+            'bg-inverse': variant === 'primary',
+          },
+        )}
+      />
+
+      <div
+        className={clsx(
+          'relative flex items-center justify-center w-full h-full whitespace-nowrap',
+          {
+            'text-primary': variant === 'secondary',
+            'text-inverse': variant === 'primary',
+            'px-11 py-6 space-x-5': size !== 'medium',
+            'px-8 py-4 space-x-3': size === 'medium',
+          },
+        )}
+      >
+        {children}
+      </div>
+    </>
   )
 }
 
@@ -38,11 +58,10 @@ function Button({
   ...buttonProps
 }: ButtonProps & JSX.IntrinsicElements['button']) {
   return (
-    <button
-      {...buttonProps}
-      className={getClassName({variant, size, className})}
-    >
-      {children}
+    <button {...buttonProps} className={getClassName({className})}>
+      <ButtonInner variant={variant} size={size}>
+        {children}
+      </ButtonInner>
     </button>
   )
 }
@@ -60,9 +79,9 @@ const ButtonLink = React.forwardRef<
         ref={ref}
         href={to}
         onClick={onClick}
-        className={getClassName({variant, className})}
+        className={getClassName({className})}
       >
-        {children}
+        <ButtonInner variant={variant}>{children}</ButtonInner>
       </a>
     )
   }
@@ -72,9 +91,9 @@ const ButtonLink = React.forwardRef<
       ref={ref}
       to={to}
       onClick={onClick}
-      className={getClassName({variant, className})}
+      className={getClassName({className})}
     >
-      {children}
+      <ButtonInner variant={variant}>{children}</ButtonInner>
     </Link>
   )
 })

--- a/app/components/call/recorder.tsx
+++ b/app/components/call/recorder.tsx
@@ -283,7 +283,11 @@ function CallRecorder({
           <Button size="medium" onClick={() => send({type: 'stop'})}>
             <SquareIcon /> <span>Stop</span>
           </Button>
-          <Button size="medium" onClick={() => send({type: 'pause'})}>
+          <Button
+            size="medium"
+            variant="secondary"
+            onClick={() => send({type: 'pause'})}
+          >
             <PauseIcon /> <span>Pause</span>
           </Button>
         </div>

--- a/app/components/call/submit-recording-form.tsx
+++ b/app/components/call/submit-recording-form.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {Form, useSubmit} from 'remix'
-import {Input, InputError, Label} from '../form-elements'
-import {Grid} from '../grid'
+import {Field} from '../form-elements'
 import {Button} from '../button'
 
 type RecordingFormData = {
@@ -71,59 +70,30 @@ function RecordingForm({audio, data}: {audio: Blob; data?: RecordingFormData}) {
       </div>
 
       <Form onSubmit={handleSubmit}>
-        <Grid nested>
-          <div className="flex flex-col col-span-full space-y-12 lg:col-span-6 lg:space-y-20">
-            <div>
-              <div className="flex items-baseline justify-between mb-4">
-                <Label htmlFor="title">Title</Label>
-                <InputError id="firstName-error">
-                  {data?.errors.title}
-                </InputError>
-              </div>
+        <Field
+          name="title"
+          label="Title"
+          defaultValue={data?.fields.title ?? ''}
+          error={data?.errors.title}
+        />
+        <Field
+          error={data?.errors.description}
+          name="description"
+          label="Description"
+          type="textarea"
+          defaultValue={data?.fields.description ?? ''}
+        />
 
-              <Input
-                id="title"
-                name="title"
-                aria-describedby="title-error-message"
-                defaultValue={data?.fields.title ?? ''}
-              />
-            </div>
+        <Field
+          error={data?.errors.keywords}
+          label="Keywords"
+          name="keywords"
+          defaultValue={data?.fields.keywords ?? ''}
+        />
 
-            <div>
-              <div className="flex items-baseline justify-between mb-4">
-                <Label htmlFor="description">Description</Label>
-                <InputError id="description-error-message">
-                  {data?.errors.description}
-                </InputError>
-              </div>
-
-              <Input
-                id="description"
-                name="description"
-                type="textarea"
-                aria-describedby="description-error-message"
-                defaultValue={data?.fields.description ?? ''}
-              />
-            </div>
-
-            <div>
-              <div className="flex items-baseline justify-between mb-4">
-                <Label htmlFor="keywords">Keywords</Label>
-                <InputError id="keywords-error-message">
-                  {data?.errors.keywords}
-                </InputError>
-              </div>
-
-              <Input
-                id="keywords"
-                name="keywords"
-                aria-describedby="keywords-error-message"
-                defaultValue={data?.fields.keywords ?? ''}
-              />
-            </div>
-            <Button type="submit">Submit Recording</Button>
-          </div>
-        </Grid>
+        <Button type="submit" className="mt-8">
+          Submit Recording
+        </Button>
       </Form>
     </div>
   )

--- a/app/components/clipboard-copy-button.tsx
+++ b/app/components/clipboard-copy-button.tsx
@@ -68,7 +68,7 @@ function ClipboardCopyButton({
     <button
       onClick={() => setState(State.Copy)}
       className={clsx(
-        'p-3 text-black whitespace-nowrap text-lg font-medium hover:bg-gray-200 focus:bg-gray-200 bg-white rounded-lg focus:outline-none shadow hover:shadow-lg focus:shadow-lg group-hover:opacity-100 peer-hover:opacity-100 hover:opacity-100 peer-focus:opacity-100 focus:opacity-100 transition lg:opacity-0',
+        'p-3 text-black whitespace-nowrap text-lg font-medium bg-white rounded-lg shadow hover:shadow-md group-hover:opacity-100 peer-hover:opacity-100 hover:opacity-100 peer-focus:opacity-100 focus:opacity-100 transition focus:ring-2 hover:ring-2 ring-white lg:opacity-0',
         {'lg:px-8 lg:py-4': variant === 'responsive'},
         className,
       )}

--- a/app/components/form-elements.tsx
+++ b/app/components/form-elements.tsx
@@ -20,7 +20,7 @@ type InputProps =
 
 function Input(props: InputProps) {
   const className = clsx(
-    'placeholder-gray-500 dark:disabled:text-blueGray-500 focus-ring px-11 py-8 w-full text-black disabled:text-gray-400 dark:text-white text-lg font-medium bg-gray-200 dark:bg-gray-800 rounded-lg',
+    'placeholder-gray-500 dark:disabled:text-blueGray-500 focus-ring px-11 py-8 w-full text-black disabled:text-gray-400 dark:text-white text-lg font-medium bg-gray-100 dark:bg-gray-800 rounded-lg',
     props.className,
   )
 
@@ -64,6 +64,7 @@ function Field({
   name,
   label,
   className,
+  description,
   id,
   ...props
 }: {
@@ -72,16 +73,24 @@ function Field({
   label: string
   className?: string
   error?: string | null
+  description?: React.ReactNode
 } & InputProps) {
   const prefix = useId()
   const inputId = id ?? `${prefix}-${name}`
   const errorId = `${inputId}-error`
+  const descriptionId = `${inputId}-description`
 
   return (
     <div className={clsx('mb-8', className)}>
       <div className="flex items-baseline justify-between mb-4">
         <Label htmlFor={inputId}>{label}</Label>
-        <InputError id={errorId}>{error}</InputError>
+        {error ? (
+          <InputError id={errorId}>{error}</InputError>
+        ) : description ? (
+          <p id={descriptionId} className="text-primary text-lg">
+            {description}
+          </p>
+        ) : null}
       </div>
 
       <Input
@@ -91,7 +100,9 @@ function Field({
         autoComplete={name}
         required
         defaultValue={defaultValue}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={
+          error ? errorId : description ? descriptionId : undefined
+        }
       />
     </div>
   )

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -186,7 +186,7 @@ function MobileMenu() {
         const state = isExpanded ? 'open' : 'closed'
         return (
           <>
-            <MenuButton className="focus:bg-secondary hover:bg-secondary text-primary inline-flex items-center justify-center p-1 w-14 h-14 border-2 border-gray-200 dark:border-gray-600 rounded-full focus:outline-none transition">
+            <MenuButton className="focus:border-primary hover:border-primary text-primary border-secondary inline-flex items-center justify-center p-1 w-14 h-14 border-2 rounded-full focus:outline-none transition">
               <svg
                 width="32"
                 height="32"
@@ -291,7 +291,13 @@ function Navbar() {
               ? 'Finish signing up'
               : 'Login'
           }
-          className="focus:border-primary hover:border-primary inline-flex items-center justify-center ml-4 w-14 h-14 text-white border-2 border-team-current rounded-full focus:outline-none transition"
+          className={clsx(
+            'focus:border-primary hover:border-primary inline-flex items-center justify-center ml-4 w-14 h-14 text-white border-2 rounded-full focus:outline-none transition',
+            {
+              'border-team-current': team !== 'UNKNOWN',
+              'border-secondary': team === 'UNKNOWN',
+            },
+          )}
         >
           <img
             className="inline w-10 h-10 bg-white rounded-full object-cover"

--- a/app/components/sections/about-section.tsx
+++ b/app/components/sections/about-section.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {images} from '../../images'
 import {H2, Paragraph} from '../typography'
-import {ArrowButton} from '../arrow-button'
+import {ArrowLink} from '../arrow-button'
 import {Grid} from '../grid'
 
 function AboutSection() {
@@ -38,9 +38,9 @@ function AboutSection() {
           pellentesq.
         </Paragraph>
 
-        <ArrowButton direction="right" className="mt-14">
-          Learn more about me{' '}
-        </ArrowButton>
+        <ArrowLink to="/about" direction="right" className="mt-14">
+          Learn more about me
+        </ArrowLink>
       </div>
     </Grid>
   )

--- a/app/components/sections/blog-section.tsx
+++ b/app/components/sections/blog-section.tsx
@@ -16,7 +16,7 @@ function BlogSection({
   articles,
   title,
   description,
-  showArrowButton,
+  showArrowButton = true,
 }: BlogSectionProps) {
   return (
     <>

--- a/app/components/sections/discord-section.tsx
+++ b/app/components/sections/discord-section.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {images} from '../../images'
 import {H2} from '../typography'
-import {ArrowButton} from '../arrow-button'
+import {ArrowLink} from '../arrow-button'
 import {Grid} from '../grid'
 import {DiscordLogo} from '../icons/discord-logo'
 
@@ -20,9 +20,9 @@ function DiscordSection() {
           Join the discord and learn to get better at react together.
         </H2>
 
-        <ArrowButton direction="right" className="mt-20">
+        <ArrowLink to="/discord" direction="right" className="mt-20">
           Learn more about the discord
-        </ArrowButton>
+        </ArrowLink>
       </div>
 
       <div className="relative hidden lg:block lg:col-span-6 lg:col-start-7">

--- a/app/components/sections/header-section.tsx
+++ b/app/components/sections/header-section.tsx
@@ -23,7 +23,7 @@ function HeaderSection({
     <Grid>
       <div
         className={clsx(
-          'flex flex-col col-span-full space-y-10 lg:flex-row lg:items-center lg:justify-between lg:space-y-0',
+          'flex flex-col col-span-full space-y-10 lg:flex-row lg:items-end lg:justify-between lg:space-y-0',
           className,
         )}
       >

--- a/app/components/sections/introduction-section.tsx
+++ b/app/components/sections/introduction-section.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {images} from '../../images'
 import {H2} from '../typography'
-import {ArrowButton} from '../arrow-button'
+import {ArrowLink} from '../arrow-button'
 import {Grid} from '../grid'
 import {VideoCard} from '../video-card'
 
@@ -27,9 +27,9 @@ function IntroductionSection() {
           rollerskater. When i’m not at the computer you can find me cruizing
           around on my one wheel.
         </H2>
-        <ArrowButton direction="right" className="mt-20">
+        <ArrowLink to="/about" direction="right" className="mt-20">
           Learn more about me
-        </ArrowButton>
+        </ArrowLink>
       </div>
     </Grid>
   )

--- a/app/components/sections/problem-solution-section.tsx
+++ b/app/components/sections/problem-solution-section.tsx
@@ -12,7 +12,7 @@ import {motion, AnimatePresence} from 'framer-motion'
 import {images} from '../../images'
 import {Grid} from '../grid'
 import {H2, H3, Paragraph} from '../typography'
-import {ArrowButton} from '../arrow-button'
+import {ArrowLink} from '../arrow-button'
 import {ArrowIcon} from '../icons/arrow-icon'
 
 function Tab({isSelected, children}: TabProps & {isSelected?: boolean}) {
@@ -164,9 +164,9 @@ function ProblemSolutionSection() {
                   vulputate non mi. Mauris vel pellentesque mauris vivamus.
                 </Paragraph>
 
-                <ArrowButton className="mt-14">
+                <ArrowLink to="/blog" className="mt-14">
                   Start reading the blog
-                </ArrowButton>
+                </ArrowLink>
               </ContentPanel>
 
               <ContentPanel active={activeTabIndex === 1}>
@@ -179,7 +179,9 @@ function ProblemSolutionSection() {
                   aliquet nulla at, gravida nunc. Nulla vitae hendrerit velit.
                 </Paragraph>
 
-                <ArrowButton className="mt-14">Explore the courses</ArrowButton>
+                <ArrowLink to="/courses" className="mt-14">
+                  Explore the courses
+                </ArrowLink>
               </ContentPanel>
 
               <ContentPanel active={activeTabIndex === 2}>
@@ -192,9 +194,9 @@ function ProblemSolutionSection() {
                   felis, porta eu convallis sit amet, vulputate non mi.
                 </Paragraph>
 
-                <ArrowButton className="mt-14">
+                <ArrowLink to="/chats" className="mt-14">
                   Start listening to the podcasts
-                </ArrowButton>
+                </ArrowLink>
               </ContentPanel>
             </TabPanels>
           </Tabs>

--- a/app/components/sections/problem-solution-section.tsx
+++ b/app/components/sections/problem-solution-section.tsx
@@ -19,7 +19,7 @@ function Tab({isSelected, children}: TabProps & {isSelected?: boolean}) {
   return (
     <ReachTab
       className={clsx(
-        'inline-flex items-center p-0 w-full focus:bg-transparent border-none lowercase space-x-8 transition',
+        'hover:text-primary inline-flex items-center p-0 w-full focus:bg-transparent border-none lowercase space-x-8 transition',
         {
           'text-primary': isSelected,
           'dark:text-blueGray-500 text-gray-400': !isSelected,

--- a/app/components/sections/testimonial-section.tsx
+++ b/app/components/sections/testimonial-section.tsx
@@ -23,7 +23,7 @@ function TestimonialSection({
     <Grid className={className}>
       <div className="flex flex-col col-span-full mb-20 space-y-10 lg:flex-row lg:items-end lg:justify-between lg:space-y-0">
         <div className="space-y-2 lg:space-y-0">
-          <H2 className="mb-3 lg:mt-6">Don’t just take my word for it.</H2>
+          <H2>Don’t just take my word for it.</H2>
           <H2 variant="secondary" as="p">
             What participants have to say.
           </H2>

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -295,7 +295,7 @@ function MdxScreen() {
                   </ul>
                   <a
                     href={externalLinks.translationContributions}
-                    className="text-secondary block mb-6 ml-5 my-3 hover:underline"
+                    className="text-secondary underlined block mb-6 ml-5 my-3"
                     target="_blank"
                     rel="noreferrer noopener"
                   >
@@ -312,7 +312,7 @@ function MdxScreen() {
 
                   <a
                     href={externalLinks.translationContributions}
-                    className="text-secondary block ml-5 hover:underline"
+                    className="text-secondary underlined block ml-5"
                     target="_blank"
                     rel="noreferrer noopener"
                   >

--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -18,6 +18,7 @@ import {useRequestInfo} from '../../utils/providers'
 import {shouldForceFresh} from '../../utils/redis.server'
 import {HeroSection} from '../../components/sections/hero-section'
 import {PlusIcon} from '../../components/icons/plus-icon'
+import {Button} from '../../components/button'
 
 type LoaderData = {
   posts: Array<MdxListItem>
@@ -164,7 +165,7 @@ function BlogHome() {
                 name="q"
                 placeholder="Search blog"
                 aria-label="Search blog"
-                className="dark:focus:bg-gray-800 placeholder-black dark:placeholder-white px-16 py-6 w-full text-black dark:text-white text-lg font-medium focus:bg-gray-100 bg-transparent border border-gray-200 dark:border-gray-600 rounded-full focus:outline-none"
+                className="text-primary bg-primary border-secondary hover:border-primary focus:border-primary focus:bg-secondary px-16 py-6 w-full text-lg font-medium border rounded-full focus:outline-none"
               />
               <div className="absolute right-8 top-0 flex items-center justify-center h-full text-blueGray-500 text-lg font-medium">
                 {matchingPosts.length}
@@ -238,12 +239,12 @@ function BlogHome() {
 
       {hasMorePosts ? (
         <div className="flex justify-center mb-64 w-full">
-          <button
-            className="dark:focus:bg-gray-800 text-primary flex items-center px-8 py-6 focus:bg-gray-100 bg-transparent border border-gray-200 dark:border-gray-600 rounded-full focus:outline-none"
+          <Button
+            variant="secondary"
             onClick={() => setIndexToShow(i => i + PAGE_SIZE)}
           >
-            <span className="mr-4">Load more articles</span> <PlusIcon />
-          </button>
+            <span>Load more articles</span> <PlusIcon />
+          </Button>
         </div>
       ) : null}
 

--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -63,6 +63,9 @@ export const meta: MetaFunction = () => {
   }
 }
 
+// should be divisible by 3 and 2 (large screen, and medium screen).
+const PAGE_SIZE = 12
+
 function BlogHome() {
   const requestInfo = useRequestInfo()
 
@@ -102,7 +105,7 @@ function BlogHome() {
     return filterPosts(allPosts, query)
   }, [allPosts, query])
 
-  const initialIndexToShow = 14
+  const initialIndexToShow = PAGE_SIZE + 1 // + 1 for the featured blog
   const [indexToShow, setIndexToShow] = React.useState(initialIndexToShow)
   // when the query changes, we want to reset the index
   React.useEffect(() => {
@@ -236,8 +239,8 @@ function BlogHome() {
       {hasMorePosts ? (
         <div className="flex justify-center mb-64 w-full">
           <button
-            onClick={() => setIndexToShow(i => i + 16)}
             className="dark:focus:bg-gray-800 text-primary flex items-center px-8 py-6 focus:bg-gray-100 bg-transparent border border-gray-200 dark:border-gray-600 rounded-full focus:outline-none"
+            onClick={() => setIndexToShow(i => i + PAGE_SIZE)}
           >
             <span className="mr-4">Load more articles</span> <PlusIcon />
           </button>

--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -66,6 +66,7 @@ export const meta: MetaFunction = () => {
 
 // should be divisible by 3 and 2 (large screen, and medium screen).
 const PAGE_SIZE = 12
+const initialIndexToShow = PAGE_SIZE + 1 // + 1 for the featured blog
 
 function BlogHome() {
   const requestInfo = useRequestInfo()
@@ -106,7 +107,6 @@ function BlogHome() {
     return filterPosts(allPosts, query)
   }, [allPosts, query])
 
-  const initialIndexToShow = PAGE_SIZE + 1 // + 1 for the featured blog
   const [indexToShow, setIndexToShow] = React.useState(initialIndexToShow)
   // when the query changes, we want to reset the index
   React.useEffect(() => {

--- a/app/routes/call.record.tsx
+++ b/app/routes/call.record.tsx
@@ -100,7 +100,7 @@ export default function RecordScreen() {
       <Grid className="mb-10 mt-24 lg:mb-24">
         <BackLink
           to="/call"
-          className="lg-col-span-8 col-span-full lg:col-start-3"
+          className="col-span-full lg:col-span-8 lg:col-start-3"
         >
           Back to overview
         </BackLink>

--- a/app/routes/chats.$season.$episode.$slug.tsx
+++ b/app/routes/chats.$season.$episode.$slug.tsx
@@ -320,7 +320,7 @@ function PodcastDetail() {
         </H2>
       </Grid>
 
-      <Grid as="main" className="mb-24 lg:mb-96">
+      <Grid as="main" className="mb-24 lg:mb-64">
         <div className="col-span-full mb-16 lg:col-span-8 lg:col-start-3">
           <iframe
             className="mb-4"

--- a/app/routes/chats.$season.$episode.$slug.tsx
+++ b/app/routes/chats.$season.$episode.$slug.tsx
@@ -308,7 +308,7 @@ function PodcastDetail() {
       <Grid className="mb-10 mt-24 lg:mb-24">
         <BackLink
           to="/chats"
-          className="lg-col-span-8 col-span-full lg:col-start-3"
+          className="col-span-full lg:col-span-8 lg:col-start-3"
         >
           Back to overview
         </BackLink>

--- a/app/routes/chats.$season.$episode.$slug.tsx
+++ b/app/routes/chats.$season.$episode.$slug.tsx
@@ -292,7 +292,7 @@ function PrevNextButton({
           {episodeListItem.guests[0]?.name}
         </p>
         <h6 className="text-secondary text-lg font-medium">
-          {episodeListItem.title}
+          {`Episode ${episodeListItem.episodeNumber}`}
         </h6>
       </div>
     </MotionLink>

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -244,7 +244,6 @@ function PodcastHome() {
         articles={data.blogRecommendations}
         title="Looking for more content?"
         description="Have a look at these articles."
-        showArrowButton
       />
     </>
   )

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -166,7 +166,7 @@ function PodcastHome() {
             <Tab
               key={season.seasonNumber}
               className={clsx(
-                'p-0 text-4xl leading-tight focus:bg-transparent border-none',
+                'hover:text-primary p-0 text-4xl leading-tight focus:bg-transparent border-none',
                 {
                   'text-primary': season.seasonNumber === seasonNumber,
                   'text-blueGray-500': season.seasonNumber !== seasonNumber,
@@ -244,6 +244,7 @@ function PodcastHome() {
         articles={data.blogRecommendations}
         title="Looking for more content?"
         description="Have a look at these articles."
+        showArrowButton
       />
     </>
   )

--- a/app/routes/courses/index.tsx
+++ b/app/routes/courses/index.tsx
@@ -84,7 +84,7 @@ function CoursesHome() {
 
       <h2 className="sr-only">Courses</h2>
 
-      <Grid className="gap-y-4 mb-24 lg:mb-96">
+      <Grid className="gap-y-4 mb-24 lg:mb-64">
         <div className="col-span-full lg:col-span-6">
           <CourseCard
             title="Epic React"

--- a/app/routes/discord.tsx
+++ b/app/routes/discord.tsx
@@ -23,6 +23,7 @@ import {TestimonialSection} from '../components/sections/testimonial-section'
 import {CourseSection} from '../components/sections/course-section'
 import {FeatureCard} from '../components/feature-card'
 import {HeroSection} from '../components/sections/hero-section'
+import {HeaderSection} from '../components/sections/header-section'
 
 export interface CategoryCardProps {
   title: string
@@ -330,16 +331,13 @@ export default function Discord() {
         className="mb-24 lg:mb-64"
       />
 
-      <Grid className="mb-24 lg:mb-64">
-        <div className="col-span-full">
-          <H2 className="mb-3 lg:mt-6">
-            Here’s a quick look at all categories.
-          </H2>
-          <H2 as="p" variant="secondary" className="mb-14">
-            Click on any category to get more info.
-          </H2>
-        </div>
+      <HeaderSection
+        title="Here’s a quick look at all categories."
+        subTitle="Click on any category to get more info."
+        className="mb-14"
+      />
 
+      <Grid className="mb-24 lg:mb-64">
         <Accordion
           collapsible
           multiple

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -63,7 +63,6 @@ function IndexRoute() {
         articles={data.blogRecommendations}
         title="Most popular from the blog."
         description="Probably the most helpful as well."
-        showArrowButton
       />
       <Spacer size="large" />
       <CourseSection />

--- a/app/routes/me.tsx
+++ b/app/routes/me.tsx
@@ -94,13 +94,10 @@ function YouScreen() {
               </div>
               <Form action="/me" method="post">
                 <input type="hidden" name="actionId" value={actionIds.logout} />
-                <button
-                  type="submit"
-                  className="flex col-span-full items-center self-end mb-12 px-11 py-6 text-black dark:text-white border-2 border-gray-600 rounded-full space-x-4 lg:col-span-8 lg:col-start-3 lg:self-auto lg:mb-0"
-                >
+                <Button type="submit" variant="secondary">
                   <LogoutIcon />
                   <H6 as="span">logout</H6>
-                </button>
+                </Button>
               </Form>
             </div>
           </div>

--- a/app/routes/me.tsx
+++ b/app/routes/me.tsx
@@ -10,7 +10,7 @@ import {getMagicLink, updateUser} from '../utils/prisma.server'
 import {requireUser, rootStorage, signOutSession} from '../utils/session.server'
 import {H2, H6} from '../components/typography'
 import {Grid} from '../components/grid'
-import {Input, Label} from '../components/form-elements'
+import {Field, Label} from '../components/form-elements'
 import {Button} from '../components/button'
 import {CheckCircledIcon} from '../components/icons/check-circled-icon'
 import {LogoutIcon} from '../components/icons/logout-icon'
@@ -87,7 +87,7 @@ function YouScreen() {
           <div className="col-span-full mb-12 lg:mb-20">
             <div className="flex flex-col-reverse items-start justify-between lg:flex-row lg:items-center">
               <div>
-                <H2 className="mb-2">Here’s your profile.</H2>
+                <H2>Here’s your profile.</H2>
                 <H2 variant="secondary" as="p">
                   Edit as you wish.
                 </H2>
@@ -112,70 +112,50 @@ function YouScreen() {
               name="actionId"
               value={actionIds.changeDetails}
             />
-            <Label className="mb-4" htmlFor="firstName">
-              First name
-            </Label>
-
-            <Input
-              className="mb-8"
+            <Field
               name="firstName"
-              id="firstName"
-              autoComplete="firstName"
+              label="First name"
               defaultValue={user.firstName}
+              autoComplete="firstName"
               required
             />
 
-            <Label className="mb-4" htmlFor="email-address">
-              Email address
-            </Label>
-
-            <Input
+            <Field
               name="email"
-              id="email-address"
+              label="Email address"
               autoComplete="email"
               required
               defaultValue={user.email}
-              className="mb-8"
               readOnly
               disabled
             />
 
-            <div className="flex flex-wrap items-baseline justify-between mb-4">
-              <Label htmlFor="discord-id">Discord</Label>
-              <p
-                id="discord-message"
-                className="dark:text-blueGray-500 text-gray-500 text-lg"
-              >
-                {user.discordId ? (
+            <Field
+              name="discord"
+              label="Discord"
+              defaultValue={userInfo.discord?.username ?? user.discordId ?? ''}
+              placeholder="n/a"
+              readOnly
+              disabled
+              description={
+                user.discordId ? (
                   <a
-                    className="text-black dark:text-white"
+                    className="underlined"
                     href={`https://discord.com/users/${user.discordId}`}
                   >
                     connected
                   </a>
                 ) : (
-                  <a
-                    className="focus-ring text-black dark:text-white rounded-lg"
-                    href={authorizeURL}
-                  >
+                  <a className="underlined" href={authorizeURL}>
                     Connect to Discord
                   </a>
-                )}
-              </p>
-            </div>
-
-            <Input
-              id="discord-id"
-              name="discord"
-              value={userInfo.discord?.username ?? user.discordId ?? ''}
-              placeholder="n/a"
-              className="mb-12 lg:mb-20"
-              aria-describedby="discord-message"
-              readOnly
-              disabled
+                )
+              }
             />
 
-            <Button type="submit">Save changes</Button>
+            <Button className="mt-8" type="submit">
+              Save changes
+            </Button>
           </Form>
 
           <div className="col-span-full lg:col-span-4 lg:col-start-8">
@@ -212,13 +192,13 @@ function YouScreen() {
 
       <Grid>
         <div className="col-span-full mb-12 lg:col-span-5 lg:col-start-8 lg:mb-0">
-          <H2 className="mb-2">Need to login somewhere else?</H2>
+          <H2>Need to login somewhere else?</H2>
           <H2 variant="secondary" as="p">
             Scan this QR code on the other device.
           </H2>
         </div>
 
-        <div className="relative col-span-full lg:col-span-5 lg:col-start-1 lg:row-start-1">
+        <div className="bg-secondary relative col-span-full p-4 rounded-lg lg:col-span-5 lg:col-start-1 lg:row-start-1">
           <img
             src={data.qrLoginCode}
             alt="Login QR Code"

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -16,11 +16,12 @@ import {tagKCDSiteSubscriber} from '../utils/convertkit.server'
 import {useTeam} from '../utils/providers'
 import {Grid} from '../components/grid'
 import {H2, H6, Paragraph} from '../components/typography'
-import {Input, InputError, Label} from '../components/form-elements'
+import {Field, InputError} from '../components/form-elements'
 import {Button} from '../components/button'
 import {CheckCircledIcon} from '../components/icons/check-circled-icon'
 import {images} from '../images'
 import {TEAM_MAP} from '../utils/onboarding'
+import {HeaderSection} from '../components/sections/header-section'
 
 type LoaderData = {
   email: string
@@ -230,19 +231,13 @@ export default function NewAccount() {
           })
         }}
       >
-        <Grid>
-          <div className="col-span-full">
-            {/* TODO: get Gil's eye on this... */}
-            <H2 className="mb-2">
-              Hi {data.email},
-              <br />
-              Let’s start with choosing a team.
-            </H2>
-            <H2 className="mb-12 lg:mb-20" variant="secondary" as="p">
-              You can’t change this later.
-            </H2>
-          </div>
+        <HeaderSection
+          title="Let’s start with choosing a team."
+          subTitle="You can’t change this later."
+          className="mb-16"
+        />
 
+        <Grid>
           {data.errors?.team ? (
             <div className="col-span-full mb-4 text-right">
               <InputError id="team-error">{data.errors.team}</InputError>
@@ -264,27 +259,30 @@ export default function NewAccount() {
           <div className="col-span-full h-20 lg:h-24" />
 
           <div className="col-span-full mb-12">
-            <H2 className="mb-2">Some basic info to remember you.</H2>
-            <H2 className="mb-12 lg:mb-20" variant="secondary" as="p">
+            <H2>Some basic info to remember you.</H2>
+            <H2 variant="secondary" as="p">
               You can change these later.
             </H2>
           </div>
 
-          <div className="col-span-full mb-12 lg:col-span-4 lg:mb-20">
-            <div className="flex items-baseline justify-between mb-4">
-              <Label htmlFor="firstName">First name</Label>
-              <InputError id="firstName-error">
-                {data.errors?.firstName}
-              </InputError>
-            </div>
-
-            <Input
+          <div className="col-span-full mb-12 lg:col-span-5 lg:mb-20">
+            <Field
               name="firstName"
-              id="firstName"
+              label="First name"
+              error={data.errors?.firstName}
               autoComplete="firstName"
-              required
               defaultValue={data.fields?.firstName ?? ''}
-              aria-describedby={data.errors ? 'firstName-error' : undefined}
+              required
+            />
+          </div>
+
+          <div className="col-span-full mb-12 lg:col-span-5 lg:col-start-7 lg:mb-20">
+            <Field
+              name="email"
+              label="Email"
+              defaultValue={data.email}
+              readOnly
+              disabled
             />
           </div>
 

--- a/app/routes/talks.tsx
+++ b/app/routes/talks.tsx
@@ -340,16 +340,20 @@ export default function TalksScreen() {
             : 'Showing all talks'}
         </H6>
 
-        {talks.map(talk => {
-          return (
-            <div
-              key={talk.slug}
-              className="md-col-span-4 col-span-full mb-4 lg:col-span-6 lg:mb-6"
-            >
-              <Card active={activeSlug === talk.slug} {...talk} />
-            </div>
-          )
-        })}
+        <div className="col-span-full">
+          <Grid nested rowGap>
+            {talks.map(talk => {
+              return (
+                <div
+                  key={talk.slug}
+                  className="col-span-full md:col-span-4 lg:col-span-6"
+                >
+                  <Card active={activeSlug === talk.slug} {...talk} />
+                </div>
+              )
+            })}
+          </Grid>
+        </div>
       </Grid>
 
       <CourseSection />

--- a/app/routes/workshops/index.tsx
+++ b/app/routes/workshops/index.tsx
@@ -77,14 +77,15 @@ function WorkshopsHome() {
             : 'Showing all workshops'}
         </H6>
 
-        {workshops.map(workshop => (
-          <div
-            key={workshop.slug}
-            className="col-span-full mb-4 md:col-span-4 lg:mb-6"
-          >
-            <WorkshopCard {...workshop} />
-          </div>
-        ))}
+        <div className="col-span-full">
+          <Grid nested rowGap>
+            {workshops.map(workshop => (
+              <div key={workshop.slug} className="col-span-full md:col-span-4">
+                <WorkshopCard {...workshop} />
+              </div>
+            ))}
+          </Grid>
+        </div>
       </Grid>
 
       <CourseSection />

--- a/styles/app.css
+++ b/styles/app.css
@@ -43,7 +43,7 @@ input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
 input:-webkit-autofill:active {
   -webkit-text-fill-color: black !important;
-  -webkit-box-shadow: 0 0 0 999px var(--color-gray-200) inset !important; /* gray-200 */
+  -webkit-box-shadow: 0 0 0 999px var(--color-gray-100) inset !important;
   background-clip: content-box !important;
 }
 
@@ -52,7 +52,7 @@ input:-webkit-autofill:active {
 .dark input:-webkit-autofill:focus,
 .dark input:-webkit-autofill:active {
   -webkit-text-fill-color: white !important;
-  -webkit-box-shadow: 0 0 0 999px var(--color-gray-800) inset !important; /* gray-800 */
+  -webkit-box-shadow: 0 0 0 999px var(--color-gray-800) inset !important;
   background-clip: content-box !important;
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -26,6 +26,14 @@
   --color-team-yellow: #ffd644;
 }
 
+.light {
+  --color-team-unknown: var(--color-black);
+}
+
+.dark {
+  --color-team-unknown: var(--color-white);
+}
+
 :focus:not(:focus-visible) {
   outline: none;
 }


### PR DESCRIPTION
A whole lot of various improvements, small, and some a little bigger.

**fixes**

- Some arrow links that didn't point to a page, now do.
- Restored the episode number in the podcast prev/next buttons.
- Couple of spacing issues on various pages.
- Restore missing arrow buttons in the recommended articles section.

**improvements**

- Improved `/blog` page
  - The gallery didn't render full rows on large screens. I've adjusted the page size, so that the pages are divisible by both 2 and 3 (medium and large screens).
  - Added hover styles to search input
- Various improvements in colors & hover styles.
  - The `team-unknown` color now depends on the theme.
  - Improved hover style of mobile menu
  - Added hover style to tabs in problem-solution section
  - Improved background color of input elements (light mode)
- Improved signup page
  - removed email from heading
  - reintroduced the disabled email field
  - changed hover state on `connect discord`
- Improved call recorder form, fixed spacing, dimensions, and the pause button is now secondary

I'm sure I'm missing something. Overall, things now just look better.