### PR TITLE
feat: disable filter buttons that would result in no matches

### DIFF
--- a/app/routes/blog/index.tsx
+++ b/app/routes/blog/index.tsx
@@ -144,6 +144,14 @@ function BlogHome() {
     ? matchingPosts.slice(0, indexToShow)
     : postsToShow.slice(1, indexToShow)
 
+  const visibleTags = isSearching
+    ? new Set(
+        matchingPosts
+          .flatMap(post => post.frontmatter.categories)
+          .filter(Boolean),
+      )
+    : new Set(data.tags)
+
   return (
     <>
       <HeroSection
@@ -181,14 +189,18 @@ function BlogHome() {
             Search blog by topics
           </H6>
           <div className="flex flex-wrap col-span-full -mb-4 -mr-4 lg:col-span-10">
-            {data.tags.map(tag => (
-              <Tag
-                key={tag}
-                tag={tag}
-                selected={query.includes(tag)}
-                onClick={() => toggleTag(tag)}
-              />
-            ))}
+            {data.tags.map(tag => {
+              const selected = query.includes(tag)
+              return (
+                <Tag
+                  key={tag}
+                  tag={tag}
+                  selected={selected}
+                  onClick={() => toggleTag(tag)}
+                  disabled={!visibleTags.has(tag) && !selected}
+                />
+              )
+            })}
           </div>
         </Grid>
       ) : null}


### PR DESCRIPTION
Or well, at least partially. When the user is only using the filter buttons, this works fine. As soon as they start using the search input as well, they can still end up in situations with 0 matches. We can prevent that by running a presearch of `${query} ${tag}` for each visible tag, but that impacts performance quite drastically.

Using the presearch would look like the snippet below. But when I implemented that, I noticed a serious delay while using the search input. Posting it here regardless, because maybe someone comes across it and have an idea on how to optimize it.

```js
const visibleTags = React.useMemo(() => {
  if (!isSearching) {
    return new Set(data.tags)
  }

  return new Set(
    matchingPosts
      .flatMap(post => post.frontmatter.categories)
      // fake a search on current query + tag to check for matches
      .filter(
        tag => tag && filterPosts(matchingPosts, `${query} ${tag}`).length,
      ),
  )
}, [data.tags, isSearching, query, matchingPosts])
```

https://user-images.githubusercontent.com/1196524/126864503-af7f1414-70e2-44bd-8ed2-8ec50ecd6d96.mp4


