### PR TITLE
feat: add caption above talks filter

### DIFF
--- a/app/routes/talks.tsx
+++ b/app/routes/talks.tsx
@@ -318,16 +318,23 @@ export default function TalksScreen() {
       />
 
       <Grid className="mb-14">
+        <H6 as="div" className="col-span-full mb-6">
+          Search talks by topics
+        </H6>
         <div className="flex flex-wrap col-span-full -mb-4 -mr-4 lg:col-span-10">
-          {data.tags.map(tag => (
-            <Tag
-              key={tag}
-              tag={tag}
-              selected={selectedTags.includes(tag)}
-              onClick={() => toggleTag(tag)}
-              disabled={!visibleTags.has(tag)}
-            />
-          ))}
+          {data.tags.map(tag => {
+            const selected = selectedTags.includes(tag)
+
+            return (
+              <Tag
+                key={tag}
+                tag={tag}
+                selected={selected}
+                onClick={() => toggleTag(tag)}
+                disabled={!visibleTags.has(tag) && !selected}
+              />
+            )
+          })}
         </div>
       </Grid>
 


### PR DESCRIPTION
Added a missing caption so that the filter has the same visual appearance as on `/blog`.

![image](https://user-images.githubusercontent.com/1196524/126864529-4910df0d-d805-4f34-958b-f300f2f59008.png)
