### PR TITLE
fix: improve various focus styles

### DIFF
--- a/app/components/arrow-button.tsx
+++ b/app/components/arrow-button.tsx
@@ -52,10 +52,13 @@ type ArrowButtonProps = {
   type?: JSX.IntrinsicElements['button']['type']
 } & ArrowButtonBaseProps
 
+// whileFocus takes precedence over whileTap, so while we can't move the arrow
+// on focus (or on tap), we can still color and animate the circle.
+// See: https://github.com/framer/motion/issues/1221
 function getBaseProps({textSize, className}: ArrowButtonBaseProps) {
   return {
     className: clsx(
-      'text-primary inline-flex items-center text-left font-medium cursor-pointer transition',
+      'text-primary inline-flex items-center text-left font-medium focus:outline-none cursor-pointer transition',
       {
         'text-xl': textSize === 'medium',
         'text-lg': textSize === 'small',
@@ -64,6 +67,7 @@ function getBaseProps({textSize, className}: ArrowButtonBaseProps) {
     ),
     initial: 'initial',
     whileHover: 'hover',
+    whileFocus: 'focus',
     whileTap: 'tap',
     animate: 'initial',
   }
@@ -98,12 +102,9 @@ function ArrowButtonContent({
               cx="30"
               cy="30"
             />
-          </svg>
-        </div>
 
-        <div className="absolute">
-          <svg width="60" height="60">
             <motion.circle
+              className="text-primary"
               stroke="currentColor"
               strokeWidth="2"
               fill="transparent"
@@ -113,6 +114,7 @@ function ArrowButtonContent({
               style={{strokeDasharray}}
               variants={{
                 hover: {strokeDashoffset: 0},
+                focus: {strokeDashoffset: 0},
                 initial: {strokeDashoffset: circumference, rotate: -90},
               }}
               transition={{damping: 0}}

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -10,7 +10,7 @@ interface ButtonProps {
 
 function getClassName({className}: {className?: string}) {
   return clsx(
-    'group relative inline-flex text-lg font-medium opacity-100 disabled:opacity-50 transition',
+    'group relative inline-flex text-lg font-medium focus:outline-none opacity-100 disabled:opacity-50 transition',
     className,
   )
 }
@@ -26,7 +26,7 @@ function ButtonInner({
         className={clsx(
           'focus-ring absolute inset-0 rounded-full opacity-100 disabled:opacity-50 transform transition',
           {
-            'border-2 border-secondary bg-primary group-hover:border-transparent':
+            'border-2 border-secondary bg-primary group-hover:border-transparent group-focus:border-transparent':
               variant === 'secondary',
             'bg-inverse': variant === 'primary',
           },

--- a/app/components/clipboard-copy-button.tsx
+++ b/app/components/clipboard-copy-button.tsx
@@ -68,7 +68,7 @@ function ClipboardCopyButton({
     <button
       onClick={() => setState(State.Copy)}
       className={clsx(
-        'p-3 text-black whitespace-nowrap text-lg font-medium bg-white rounded-lg shadow hover:shadow-md group-hover:opacity-100 peer-hover:opacity-100 hover:opacity-100 peer-focus:opacity-100 focus:opacity-100 transition focus:ring-2 hover:ring-2 ring-white lg:opacity-0',
+        'p-3 text-black whitespace-nowrap text-lg font-medium bg-white rounded-lg focus:outline-none shadow hover:shadow-md group-hover:opacity-100 peer-hover:opacity-100 hover:opacity-100 peer-focus:opacity-100 focus:opacity-100 transition focus:ring-2 hover:ring-2 ring-white lg:opacity-0',
         {'lg:px-8 lg:py-4': variant === 'responsive'},
         className,
       )}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -111,13 +111,22 @@ function AboutSection() {
       </p>
 
       <div className="text-secondary flex mt-6 space-x-4">
-        <a className="hover:text-primary" href={externalLinks.github}>
+        <a
+          className="hover:text-primary focus:text-primary focus:outline-none"
+          href={externalLinks.github}
+        >
           <GithubIcon />
         </a>
-        <a className="hover:text-primary" href={externalLinks.youtube}>
+        <a
+          className="hover:text-primary focus:text-primary focus:outline-none"
+          href={externalLinks.youtube}
+        >
           <YoutubeIcon />
         </a>
-        <a className="hover:text-primary" href={externalLinks.twitter}>
+        <a
+          className="hover:text-primary focus:text-primary focus:outline-none"
+          href={externalLinks.twitter}
+        >
           <TwitterIcon />
         </a>
       </div>
@@ -130,7 +139,7 @@ function FooterLink({name, href}: FooterLinkProps) {
     <li className="py-1">
       <a
         href={href}
-        className="text-secondary hover:text-primary underlined inline-block whitespace-nowrap text-lg"
+        className="text-secondary hover:text-primary focus:text-primary underlined inline-block whitespace-nowrap text-lg focus:outline-none"
       >
         {name}
       </a>

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -153,13 +153,13 @@ function ArticleFooter() {
           <H6 as="h2">Share article</H6>
           {/* TODO: fix links */}
           <Link
-            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            className="dark:hover:text-white underlined dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
             to="/"
           >
             Facebook
           </Link>
           <Link
-            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            className="dark:hover:text-white underlined dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
             to="/"
           >
             Twitter
@@ -168,14 +168,14 @@ function ArticleFooter() {
 
         <div className="flex">
           <Link
-            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            className="underlined dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
             to="/"
           >
             Discuss on Twitter
           </Link>
           <span className="self-center mx-3 text-xs">•</span>
           <Link
-            className="dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
+            className="underlined dark:hover:text-white dark:focus:text-white hover:text-black focus:text-black focus:outline-none"
             to="/"
           >
             Edit on GitHub
@@ -283,7 +283,7 @@ function MdxScreen() {
                   </ul>
                   <a
                     href={externalLinks.translationContributions}
-                    className="text-secondary underlined hover:text-primary block mb-6 ml-5 my-3 text-lg font-medium transition"
+                    className="text-secondary underlined hover:text-primary focus:text-primary block mb-6 ml-5 my-3 text-lg font-medium focus:outline-none"
                     target="_blank"
                     rel="noreferrer noopener"
                   >
@@ -298,7 +298,7 @@ function MdxScreen() {
 
                   <a
                     href={externalLinks.translationContributions}
-                    className="text-secondary underlined hover:text-primary block ml-5 text-lg font-medium transition"
+                    className="text-secondary underlined hover:text-primary focus:text-primary block ml-5 text-lg font-medium focus:outline-none"
                     target="_blank"
                     rel="noreferrer noopener"
                   >

--- a/app/routes/chats.$season.$episode.$slug.tsx
+++ b/app/routes/chats.$season.$episode.$slug.tsx
@@ -204,10 +204,10 @@ function Transcript({
       {collapsed ? (
         <button
           onClick={() => setCollapsed(false)}
-          className="text-primary inline-flex items-center mt-16 text-xl transition"
+          className="group text-primary inline-flex items-center mt-16 text-xl focus:outline-none transition"
         >
           <span>Read the full transcript</span>
-          <span className="inline-flex flex-none items-center justify-center ml-8 p-1 w-14 h-14 border-2 border-gray-200 dark:border-gray-600 rounded-full">
+          <span className="group-hover:border-primary group-focus:border-primary inline-flex flex-none items-center justify-center ml-8 p-1 w-14 h-14 border-2 border-gray-200 dark:border-gray-600 rounded-full">
             <PlusIcon />
           </span>
         </button>

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -166,7 +166,7 @@ function PodcastHome() {
             <Tab
               key={season.seasonNumber}
               className={clsx(
-                'hover:text-primary p-0 text-4xl leading-tight focus:bg-transparent border-none',
+                'hover:text-primary p-0 text-4xl leading-tight focus:bg-transparent border-none focus:outline-none',
                 {
                   'text-primary': season.seasonNumber === seasonNumber,
                   'text-blueGray-500': season.seasonNumber !== seasonNumber,
@@ -180,6 +180,7 @@ function PodcastHome() {
                 off, but more importantly it'll allow people to meta-click it.
               */}
               <Link
+                className="focus:text-primary focus:outline-none"
                 to={String(season.seasonNumber).padStart(2, '0')}
                 onClick={e => {
                   if (e.metaKey) {

--- a/app/routes/chats/$season.tsx
+++ b/app/routes/chats/$season.tsx
@@ -44,15 +44,19 @@ export default function Screen() {
   const {sortOrder} = useChatsEpisodeUIState()
   const episodes = orderBy(season.episodes, 'episodeNumber', sortOrder)
   return episodes.map(episode => (
-    <Link key={episode.slug} to={getCWKEpisodePath(episode)}>
+    <Link
+      className="group focus:outline-none"
+      key={episode.slug}
+      to={getCWKEpisodePath(episode)}
+    >
       <Grid
         nested
-        className="group relative py-10 border-b border-gray-200 dark:border-gray-600 lg:py-5"
+        className="relative py-10 border-b border-gray-200 dark:border-gray-600 lg:py-5"
       >
-        <div className="bg-secondary absolute -inset-px group-hover:block hidden -mx-6 rounded-lg" />
+        <div className="bg-secondary absolute -inset-px group-focus:block group-hover:block hidden -mx-6 rounded-lg" />
 
         <div className="relative flex-none col-span-1">
-          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transform scale-0 group-hover:scale-100 transition">
+          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-focus:opacity-100 group-hover:opacity-100 transform scale-0 group-hover:scale-100 transition">
             <div className="flex-none p-4 text-gray-800 bg-white rounded-full">
               <TriangleIcon size={12} />
             </div>

--- a/styles/app.css
+++ b/styles/app.css
@@ -81,6 +81,9 @@ light-mode {
 .html a {
   color: var(--color-black);
 }
+.html a:focus {
+  outline: none;
+}
 
 .dark .html a {
   color: var(--color-white);

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -27,7 +27,7 @@
 
 @layer utilities {
   .focus-ring {
-    @apply focus:outline-none focus-within:outline-none transition disabled:ring-0 hover:ring-2 focus:ring-2 focus-within:ring-2 group-hover:ring-2 hover:ring-team-current focus:ring-team-current focus-within:ring-team-current group-hover:ring-team-current ring-team-current ring-offset-4 dark:ring-offset-gray-900 ring-offset-white;
+    @apply focus:outline-none focus-within:outline-none transition duration-300 disabled:ring-0 hover:ring-2 focus:ring-2 focus-within:ring-2 group-hover:ring-2 group-focus:ring-2 hover:ring-team-current focus:ring-team-current focus-within:ring-team-current group-hover:ring-team-current group-focus:ring-team-current ring-team-current ring-offset-4 dark:ring-offset-gray-900 ring-offset-white;
   }
 
   .bg-primary {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -137,6 +137,7 @@ module.exports = {
                 },
                 'a:hover,a:focus': {
                   textDecoration: 'underline',
+                  outline: 'none',
                 },
                 strong: {
                   fontWeight: theme('fontWeight.medium'),


### PR DESCRIPTION
I've run through all the pages, and fixed a bunch of focus styles. There are still a few things showing the native outline, but for those, I need a bit more inspiration.

I'm also working on a workaround for https://github.com/framer/motion/issues/1221. This PR already highlights at least the circle of arrow buttons, but it would be nice if the arrow moved as well, (also on <kbd>enter</kbd>). Got something working, and will submit it soon via dedicated PR for you to review.