### PR TITLE
feat: add 'help link' to team stats

### DIFF
--- a/app/components/team-stats.tsx
+++ b/app/components/team-stats.tsx
@@ -127,11 +127,27 @@ function TeamStats({
 
   return (
     <div
-      className={clsx('inline-flex flex-col justify-end', {
+      className={clsx('group relative inline-flex flex-col justify-end', {
         'justify-end': direction === 'down',
         'justify-start': direction === 'up',
       })}
     >
+      <div
+        className={clsx(
+          'underlined absolute right-0 h-8 text-sm opacity-0 group-hover:opacity-100 transition',
+          {
+            '-top-8': direction === 'down',
+            '-bottom-20': direction === 'up',
+          },
+        )}
+      >
+        <a
+          className="text-secondary hover:text-primary underlined"
+          href="{/* TODO: add correct url */}"
+        >
+          what's this?
+        </a>
+      </div>
       <ul
         className={clsx(
           'relative flex px-4 h-0 border-team-current overflow-visible',


### PR DESCRIPTION
Link still needs to point to some page.

Alternative ideas, instead of the text we could render a [`(?)`](https://iconic.app/help-circle/) or [`(i)`](https://iconic.app/information/) svg. Maybe a bit more subtle.

https://user-images.githubusercontent.com/1196524/127175550-a8e78b82-636e-4a75-bb75-874e78bec634.mp4

