### PR TITLE
feat: style homework links, reduce spacing, sync font-size

### DIFF
--- a/app/routes/chats.$season.$episode.$slug.tsx
+++ b/app/routes/chats.$season.$episode.$slug.tsx
@@ -89,21 +89,18 @@ function Homework({
         <span>Homework</span>
       </H6>
 
-      <ul className="text-primary">
+      <ul className="text-primary html -mb-10 text-lg font-medium">
         {homeworkHTMLs.map(homeworkHTML => (
           <li
             key={homeworkHTML}
-            className="flex pb-12 pt-8 border-t border-gray-200 dark:border-gray-600"
+            className="border-secondary flex pb-10 pt-8 border-t"
           >
             <CheckCircledIcon
               className="flex-none mr-6 text-gray-400 dark:text-gray-600"
               size={24}
             />
 
-            <div
-              className="text-lg font-medium"
-              dangerouslySetInnerHTML={{__html: homeworkHTML}}
-            />
+            <div dangerouslySetInnerHTML={{__html: homeworkHTML}} />
           </li>
         ))}
       </ul>
@@ -118,13 +115,16 @@ function Resources({resources = []}: {resources: CWKEpisode['resources']}) {
         Resources
       </h4>
 
-      <ul className="text-primary space-y-8">
+      <ul className="text-secondary text-lg font-medium space-y-8 lg:space-y-2">
         {resources.map(resource => (
           <li key={resource.url}>
-            <a href={resource.url} className="text-secondary text-xl space-x-4">
+            <a
+              href={resource.url}
+              className="hover:text-primary focus:text-primary focus:outline-none transition"
+            >
               <span>{resource.name}</span>
-              <span className="inline-block align-bottom">
-                <ArrowIcon direction="top-right" />
+              <span className="inline-block align-top ml-4 mt-1">
+                <ArrowIcon size={26} direction="top-right" />
               </span>
             </a>
           </li>

--- a/styles/app.css
+++ b/styles/app.css
@@ -84,15 +84,23 @@ light-mode {
 .html a:focus {
   outline: none;
 }
-
 .dark .html a {
   color: var(--color-white);
+}
+
+.html.text-primary a {
+  color: var(--color-gray-500);
+}
+
+.dark .html.text-primary a {
+  color: var(--color-blueGray-500);
 }
 
 .html a,
 a.underlined {
   position: relative;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .html a:after,


### PR DESCRIPTION
I'm not sure why the designs show the "resource" links in a larger font size than "homework", making these the same size definitely looks better.

I've also reduced the size of spacings in the homework & resource sections, and styled the links in homework to have a different color than the text, and show an underline on focus&hover.