### PR TITLE
feat: remove focus outline from underlined links

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -81,9 +81,7 @@ light-mode {
 .html a {
   color: var(--color-black);
 }
-.html a:focus {
-  outline: none;
-}
+
 .dark .html a {
   color: var(--color-white);
 }
@@ -101,6 +99,11 @@ a.underlined {
   position: relative;
   text-decoration: none;
   white-space: nowrap;
+}
+
+.html a:focus,
+a.underlined:focus {
+  outline: none;
 }
 
 .html a:after,


### PR DESCRIPTION
Make sure that non of the 'underlined' links get outlines on focus. This fixes the discord link in `/me`.