### PR TITLE
feat: add focus style to sort chat/call buttons

### DIFF
--- a/app/routes/call.tsx
+++ b/app/routes/call.tsx
@@ -103,20 +103,23 @@ export default function CallHomeScreen() {
           </H6>
 
           <button
-            className="text-primary inline-flex items-center text-lg font-medium"
+            className="group text-primary relative text-lg font-medium focus:outline-none"
             onClick={() => setSortOrder(o => (o === 'asc' ? 'desc' : 'asc'))}
           >
-            {sortOrder === 'asc' ? (
-              <>
-                Showing oldest first
-                <ChevronUpIcon className="ml-2 text-gray-400" />
-              </>
-            ) : (
-              <>
-                Showing newest first
-                <ChevronDownIcon className="ml-2 text-gray-400" />
-              </>
-            )}
+            <div className="bg-secondary absolute -bottom-2 -left-4 -right-4 -top-2 rounded-lg opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition" />
+            <span className="relative inline-flex items-center">
+              {sortOrder === 'asc' ? (
+                <>
+                  Showing oldest first
+                  <ChevronUpIcon className="ml-2 text-gray-400" />
+                </>
+              ) : (
+                <>
+                  Showing newest first
+                  <ChevronDownIcon className="ml-2 text-gray-400" />
+                </>
+              )}
+            </span>
           </button>
         </div>
 

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -208,21 +208,23 @@ function PodcastHome() {
             </H6>
 
             <button
-              className="text-primary inline-flex items-center text-lg font-medium"
+              className="group text-primary relative text-lg font-medium focus:outline-none"
               onClick={() => setSortOrder(o => (o === 'asc' ? 'desc' : 'asc'))}
             >
-              {sortOrder === 'asc' ? (
-                <>
-                  Showing oldest first
-                  <ChevronUpIcon className="ml-2 text-gray-400" />
-                </>
-              ) : null}
-              {sortOrder === 'desc' ? (
-                <>
-                  Showing newest first
-                  <ChevronDownIcon className="ml-2 text-gray-400" />
-                </>
-              ) : null}
+              <div className="bg-secondary absolute -bottom-2 -left-4 -right-4 -top-2 rounded-lg opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition" />
+              <span className="relative inline-flex items-center">
+                {sortOrder === 'asc' ? (
+                  <>
+                    Showing oldest first
+                    <ChevronUpIcon className="ml-2 text-gray-400" />
+                  </>
+                ) : (
+                  <>
+                    Showing newest first
+                    <ChevronDownIcon className="ml-2 text-gray-400" />
+                  </>
+                )}
+              </span>
             </button>
           </div>
         ) : null}

--- a/app/routes/chats.tsx
+++ b/app/routes/chats.tsx
@@ -233,7 +233,7 @@ function PodcastHome() {
           {data.seasons.map(season => (
             <TabPanel
               key={season.seasonNumber}
-              className="border-t border-gray-200 dark:border-gray-600"
+              className="border-t border-gray-200 dark:border-gray-600 focus:outline-none"
             >
               <ChatsEpisodeUIStateProvider value={{sortOrder}}>
                 <Outlet />


### PR DESCRIPTION
Fixed the hover and focus style of the sort buttons on the `/chat` and `/call` pages, by adding a background color.