### PR TITLE
feat: remove tap highlight for touch devices

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -38,6 +38,10 @@
   outline: none;
 }
 
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,


### PR DESCRIPTION
On android, the browser shows a light-blueish overlay on the tapped element. As all our elements do something on focus or tap, we already have something better. This removes the native style, a lot like removing the native focus outline.