### PR TITLE
feat: improve focus styles call recorder

### DIFF
--- a/app/routes/call.record.tsx
+++ b/app/routes/call.record.tsx
@@ -76,9 +76,9 @@ function Record({
     <Grid nested className="border-b border-gray-200 dark:border-gray-600">
       <Link
         to={active ? './' : slug}
-        className="text-primary group relative flex flex-col col-span-full py-5 text-xl font-medium"
+        className="text-primary group relative flex flex-col col-span-full py-5 text-xl font-medium focus:outline-none"
       >
-        <div className="bg-secondary absolute -inset-px group-hover:block hidden -mx-6 rounded-lg" />
+        <div className="bg-secondary absolute -inset-px group-hover:block group-focus:block hidden -mx-6 rounded-lg" />
         <span className="relative">{title}</span>
       </Link>
       <div className="col-span-full">

--- a/app/routes/call.record/$callId.tsx
+++ b/app/routes/call.record/$callId.tsx
@@ -73,7 +73,7 @@ export default function Screen() {
           />
           <input type="hidden" name="callId" value={data.call.id} />
           <button
-            className="text-primary dark:hover:border-red-500 px-10 py-3 hover:text-red-500 text-lg font-medium border-2 border-gray-400 dark:border-gray-600 hover:border-red-500 rounded-full transition"
+            className="text-primary dark:focus:border-red-500 dark:hover:border-red-500 px-10 py-3 hover:text-red-500 focus:text-red-500 text-lg font-medium border-2 border-gray-400 dark:border-gray-600 focus:border-red-500 hover:border-red-500 rounded-full focus:outline-none transition"
             type="submit"
           >
             Delete


### PR DESCRIPTION
- use a background color instead of outline on accordion
- use the hover styles instead of outline on the `delete` button